### PR TITLE
Slightly adjust map icons and merchant item descriptions in ultrawide

### DIFF
--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -85,9 +85,9 @@ void HandleAspectRatio(uint32_t intGameWidth, uint32_t intGameHeight)
 		fNewInvItemNamePos = 385;
 		fNewFilesTitlePos = 370;
 		fNewFilesItemsPos = 375;
-		fNewMapIconsPos = 340;
+		fNewMapIconsPos = 336;
 		fNewMerchItemListPos = 333;
-		fNewMerchItemDescPos = 400;
+		fNewMerchItemDescPos = 395;
 		fNewMerchGreetingPos = 380;
 		fNewTItemNamesPos = 385;
 		fNewRadioNamesPos = 380;


### PR DESCRIPTION
Map in 21:9 should exactly match the 16:9 positioning now. Also more accurately match the positioning for merchant item description text.

It bugged me slightly, so I figured I'd fix it myself and save you the trouble :)