### PR TITLE
Add `WindowBorderless`, `WindowPositionX` & `WindowPositionY` settings, fixes #13

### DIFF
--- a/settings/winmm.ini
+++ b/settings/winmm.ini
@@ -23,6 +23,14 @@ FixBlurryImage = true
 ; Disables the film grain overlay that is present in most sections of the game.
 DisableFilmGrain = true
 
+; Whether to use a borderless-window when using windowed-mode
+WindowBorderless = false
+
+; Position to draw the game window when using windowed mode
+; -1 will use the games default (usually places it at 0,0)
+WindowPositionX = -1
+WindowPositionY = -1
+
 [MISC]
 ; When running in 60 FPS, some QTEs require extremely fast button presses to work. This gets even worse in Professional difficulty,
 ; making it seem almost impossible to survive the minecart and the statue bridge QTEs.


### PR DESCRIPTION
Tested with 1.1.0 & 1.0.6, hopefully sig should match 1.0.6 JP too.

Might be nice if the INI could also be updated when user moves the window around, via the WndProc hook maybe, though it seems RE4 doesn't always let you move the window for some reason...

(also I still wonder if there's any way to make Windows automatically move it out of the way of taskbar, didn't have any luck with that yet though)