### PR TITLE
Add hooks to make DoF blur closer to GC, add `EnableGCBlur` setting

### DIFF
--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -59,6 +59,7 @@ bool bUseMemcpy;
 bool bIgnoreFPSWarning;
 bool bMemOptimi;
 bool bWindowBorderless;
+bool bEnableGCBlur;
 
 uintptr_t jmpAddrChangedRes;
 uintptr_t* ptrYMovieResFromFile;
@@ -495,6 +496,237 @@ BOOL __stdcall SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter, int X, int Y, 
 	return SetWindowPos(hWnd, hWndInsertAfter, windowX, windowY, cx, cy, uFlags);
 }
 
+struct Filter01Params
+{
+	void* OtHandle; // OT = render pass or something
+	int Distance;
+	float AlphaLevel;
+	uint8_t FocusMode;
+	uint8_t UnkD; // if set then it uses code-path with constant 4-pass loop, else uses pass with loop based on AlphaLevel
+};
+
+float* ptr_InternalWidth;
+float* ptr_InternalHeight;
+float* ptr_InternalHeightScale;
+int* ptr_RenderHeight;
+uint32_t* ptr_filter01_buff;
+
+typedef void(__cdecl* GXBegin_Fn)(int a1, int a2, short a3);
+typedef void(__cdecl* GXPosition3f32_Fn)(float a1, float a2, float a3);
+typedef void(__cdecl* GXColor4u8_Fn)(uint8_t a1, uint8_t a2, uint8_t a3, uint8_t a4);
+typedef void(__cdecl* GXTexCoord2f32_Fn)(float a1, float a2);
+typedef void(__cdecl* GXShaderCall_Maybe_Fn)(int a1);
+
+typedef void(__cdecl* GXSetTexCopySrc_Fn)(short a1, short a2, short a3, short a4);
+typedef void(__cdecl* GXSetTexCopyDst_Fn)(short a1, short a2, int a3, char a4);
+typedef void(__cdecl* GXCopyTex_Fn)(uint32_t a1, char a2, int a3);
+
+GXBegin_Fn GXBegin = nullptr;
+GXPosition3f32_Fn GXPosition3f32 = nullptr;
+GXColor4u8_Fn GXColor4u8 = nullptr;
+GXTexCoord2f32_Fn GXTexCoord2f32 = nullptr;
+GXShaderCall_Maybe_Fn GXShaderCall_Maybe = nullptr;
+GXSetTexCopySrc_Fn GXSetTexCopySrc = nullptr;
+GXSetTexCopyDst_Fn GXSetTexCopyDst = nullptr;
+GXCopyTex_Fn GXCopyTex = nullptr;
+
+void __cdecl Filter01Render_Hook1(Filter01Params* params)
+{
+	float blurPositionOffset = params->AlphaLevel * 0.33f;
+
+	float GameWidth = *ptr_InternalWidth;
+	float GameHeight = *ptr_InternalHeight;
+
+	// Code that was in original Filter01Render
+	// Seems to usually be 1/8th of 448, might change depending on ptr_InternalHeightScale / ptr_RenderHeight though
+	// Offset is used to fix Y coords of the blur effect, otherwise the blur ends up offset from the image for some reason
+	float heightScaled = *ptr_InternalHeightScale * 448.0f;
+	float offsetY = 448.0f * (heightScaled - *ptr_RenderHeight) / (heightScaled + heightScaled);
+
+	float deltaX = 0;
+	float deltaY = 0;
+	float posZ = params->Distance;
+	for (int loopIdx = 0; loopIdx < 4; loopIdx++)
+	{
+		// Main reason for this hook is to add the deltaX/deltaY vars below, needed for the DoF effect to work properly
+		// GC debug had this, but was removed in X360 port onwards for some reason
+		// (yet even though this was removed, the X360 devs did add the code for offsetY above to fix the blur...)
+
+		if (loopIdx == 0) {
+			deltaX = 0.0 - blurPositionOffset;
+			deltaY = 0.0 - blurPositionOffset;
+		}
+		else if (loopIdx == 1) {
+			deltaX = 0.0 + blurPositionOffset;
+			deltaY = 0.0 + blurPositionOffset;
+		}
+		else if (loopIdx == 2) {
+			deltaX = 0.0 + blurPositionOffset;
+			deltaY = 0.0 - blurPositionOffset;
+		}
+		else if (loopIdx == 3) {
+			deltaX = 0.0 - blurPositionOffset;
+			deltaY = 0.0 + blurPositionOffset;
+		}
+
+		posZ = posZ + 100.f;
+		if (posZ > 65536)
+			posZ = 65536;
+
+		GXBegin(0x80, 0, 4);
+
+		GXPosition3f32(0.0 + deltaX, 0.0 + deltaY + offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(0.0, 0.0);
+
+		GXPosition3f32(0.0 + deltaX + GameWidth, 0.0 + deltaY + offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(1.0, 0.0);
+
+		GXPosition3f32(0.0 + deltaX + GameWidth, 0.0 + deltaY + GameHeight - offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(1.0, 1.0);
+
+		GXPosition3f32(0.0 + deltaX, 0.0 + deltaY + GameHeight - offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(0.0, 1.0);
+
+		GXShaderCall_Maybe(0xE);
+	}
+
+	if (params->AlphaLevel > 1)
+	{
+		float blurAlpha = (params->AlphaLevel - 1) * 25;
+		if (blurAlpha > 255)
+			blurAlpha = 255;
+
+		if (blurAlpha > 0)
+		{
+			GXSetTexCopySrc(0, 0, GameWidth, GameHeight);
+			GXSetTexCopyDst(((int)GameWidth) >> 1, ((int)GameHeight) >> 1, 6, 1);
+			GXCopyTex(*ptr_filter01_buff, 0, 0);
+
+			GXBegin(0x80, 0, 4);
+
+			GXPosition3f32(0.25 + deltaX, 0.25 + deltaY + offsetY, posZ);
+			GXColor4u8(0xFF, 0xFF, 0xFF, (int)blurAlpha);
+			GXTexCoord2f32(0.0, 0.0);
+
+			GXPosition3f32(0.25 + deltaX + GameWidth, 0.25 + deltaY + offsetY, posZ);
+			GXColor4u8(0xFF, 0xFF, 0xFF, (int)blurAlpha);
+			GXTexCoord2f32(1.0, 0.0);
+
+			GXPosition3f32(0.25 + deltaX + GameWidth, 0.25 + deltaY + GameHeight - offsetY, posZ);
+			GXColor4u8(0xFF, 0xFF, 0xFF, (int)blurAlpha);
+			GXTexCoord2f32(1.0, 1.0);
+
+			GXPosition3f32(0.25 + deltaX, 0.25 + deltaY + GameHeight - offsetY, posZ);
+			GXColor4u8(0xFF, 0xFF, 0xFF, (int)blurAlpha);
+			GXTexCoord2f32(0.0, 1.0);
+
+			GXShaderCall_Maybe(0xE);
+		}
+	}
+}
+
+void __cdecl Filter01Render_Hook2(Filter01Params* params)
+{
+	float GameWidth = *ptr_InternalWidth;
+	float GameHeight = *ptr_InternalHeight;
+
+	float AlphaLvlTable[] = { // level_tbl1 in GC debug
+		0,
+		0.60, // 0.60000002
+		1.5,
+		2.60, // 2.5999999
+		1.5,
+		1.6,
+		1.6,
+		2.5,
+		2.60, // 2.5999999
+		4.5,
+		6.60 // 6.5999999
+	};
+
+	int AlphaLevel_floor = (int)floorf(params->AlphaLevel); // TODO: should this be ceil instead?
+	float blurPositionOffset = AlphaLvlTable[AlphaLevel_floor];
+
+	int numBlurPasses = 4;
+	switch (AlphaLevel_floor)
+	{
+	case 0:
+		numBlurPasses = 0;
+		break;
+	case 1:
+	case 2:
+	case 3:
+		numBlurPasses = 1;
+		break;
+	case 4:
+		numBlurPasses = 2;
+		break;
+	case 5:
+		numBlurPasses = 3;
+		break;
+	}
+
+	// Code that was in original Filter01Render
+	// Seems to usually be 1/8th of 448, might change depending on ptr_InternalHeightScale / ptr_RenderHeight though
+	// Offset is used to fix Y coords of the blur effect, otherwise the blur ends up offset from the image for some reason
+	float heightScaled = *ptr_InternalHeightScale * 448.0f;
+	float offsetY = 448.0f * (heightScaled - *ptr_RenderHeight) / (heightScaled + heightScaled);
+
+	float deltaX = 0;
+	float deltaY = 0;
+	float posZ = params->Distance;
+	for (int loopIdx = 0; loopIdx < numBlurPasses; loopIdx++)
+	{
+		// Main reason for this hook is to add the deltaX/deltaY vars below, needed for the DoF effect to work properly
+		// GC debug had this, but was removed in X360 port onwards for some reason
+		// (yet even though this was removed, the X360 devs did add the code for offsetY above to fix the blur...)
+
+		if (loopIdx == 0) {
+			deltaX = 0.0 - blurPositionOffset;
+			deltaY = 0.0 - blurPositionOffset;
+		}
+		else if (loopIdx == 1) {
+			deltaX = 0.0 + blurPositionOffset;
+			deltaY = 0.0 + blurPositionOffset;
+		}
+		else if (loopIdx == 2) {
+			deltaX = 0.0 + blurPositionOffset;
+			deltaY = 0.0 - blurPositionOffset;
+		}
+		else if (loopIdx == 3) {
+			deltaX = 0.0 - blurPositionOffset;
+			deltaY = 0.0 + blurPositionOffset;
+		}
+
+		posZ = posZ + 100.f;
+		if (posZ > 65536)
+			posZ = 65536;
+
+		GXBegin(0xA0, 0, 4); // TODO: 0xA0 (GX_TRIANGLEFAN) in PC, 0x80 (GX_QUADS) in GC - should this be changed?
+
+		GXPosition3f32(0.0 + deltaX, 0.0 + deltaY + offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(0.0, 0.0);
+
+		GXPosition3f32(0.0 + deltaX + GameWidth, 0.0 + deltaY + offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(1.0, 0.0);
+
+		GXPosition3f32(0.0 + deltaX + GameWidth, 0.0 + deltaY + GameHeight - offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(1.0, 1.0);
+
+		GXPosition3f32(0.0 + deltaX, 0.0 + deltaY + GameHeight - offsetY, posZ);
+		GXColor4u8(0xFF, 0xFF, 0xFF, 0x80);
+		GXTexCoord2f32(0.0, 1.0);
+
+		GXShaderCall_Maybe(0xE);
+	}
+}
 
 void ReadSettings()
 {
@@ -506,6 +738,7 @@ void ReadSettings()
 	bRestorePickupTransparency = iniReader.ReadBoolean("DISPLAY", "RestorePickupTransparency", true);
 	bFixBlurryImage = iniReader.ReadBoolean("DISPLAY", "FixBlurryImage", false);
 	bDisableFilmGrain = iniReader.ReadBoolean("DISPLAY", "DisableFilmGrain", false);
+	bEnableGCBlur = iniReader.ReadBoolean("DISPLAY", "EnableGCBlur", false);
 	bWindowBorderless = iniReader.ReadBoolean("DISPLAY", "WindowBorderless", false);
 	iWindowPositionX = iniReader.ReadInteger("DISPLAY", "WindowPositionX", -1);
 	iWindowPositionY = iniReader.ReadInteger("DISPLAY", "WindowPositionY", -1);
@@ -644,6 +877,63 @@ void GetPointers()
 	pattern = hook::pattern("81 FF ? ? ? ? 73 ? 8B 15 ? ? ? ? 81 C2 ? ? ? ? 89 56 ? 83 0E");
 	ptrg_MemPool_SubScreen6 = pattern.count(1).get(0).get<uint32_t>(2);
 	ptrp_MemPool_SubScreen10 = pattern.count(1).get(0).get<uint32_t>(16);
+
+	// GC blur fix
+	pattern = hook::pattern("6A 04 53 68 A0 00 00 00 E8 ? ? ? ?");
+	uint8_t* fnCallPtr = pattern.count(1).get(0).get<uint8_t>(9);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXBegin = (GXBegin_Fn)fnCallPtr;
+
+	pattern = hook::pattern("D9 ? ? ? ? ? D9 ? ? ? D9 ? ? ? ? ? D9 ? ? ? D9 EE D9 ? ? E8 ? ? ? ?");
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(26);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXPosition3f32 = (GXPosition3f32_Fn)fnCallPtr;
+
+	pattern = hook::pattern("68 80 00 00 00 68 FF 00 00 00 68 FF 00 00 00 68 FF 00 00 00 E8 ? ? ? ?");
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(21);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXColor4u8 = (GXColor4u8_Fn)fnCallPtr;
+
+	pattern = hook::pattern("E8 ? ? ? ? D9 EE 83 ? ? D9 ? ? ? D9 ? ? E8 ? ? ? ?");
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(18);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXTexCoord2f32 = (GXTexCoord2f32_Fn)fnCallPtr;
+
+	pattern = hook::pattern("D9 EE D9 ? ? E8 ? ? ? ? 6A 0E E8 ? ? ? ?");
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(13);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXShaderCall_Maybe = (GXShaderCall_Maybe_Fn)fnCallPtr;
+
+	pattern = hook::pattern("E8 ? ? ? ? 6A 01 6A 06 D9");
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(1);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXSetTexCopySrc = (GXSetTexCopySrc_Fn)fnCallPtr;
+
+	uint32_t* varPtr = pattern.count(1).get(0).get<uint32_t>(11);
+	ptr_InternalHeight = (float*)*varPtr;
+
+	pattern = hook::pattern("D1 E8 50 D9 AD ? ? ? ? D9 05 ? ? ? ?");
+	varPtr = pattern.count(1).get(0).get<uint32_t>(11);
+	ptr_InternalWidth = (float*)*varPtr;
+
+	pattern = hook::pattern("D1 E9 51 D9 AD ? ? ? ? E8 ? ? ? ? 8B 15");
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(10);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXSetTexCopyDst = (GXSetTexCopyDst_Fn)fnCallPtr;
+
+	varPtr = pattern.count(1).get(0).get<uint32_t>(16);
+	ptr_filter01_buff = (uint32_t*)*varPtr;
+
+	fnCallPtr = pattern.count(1).get(0).get<uint8_t>(27);
+	fnCallPtr += sizeof(int32_t) + *(int32_t*)fnCallPtr;
+	GXCopyTex = (GXCopyTex_Fn)fnCallPtr;
+
+	pattern = hook::pattern("83 C4 ? D9 ? ? ? ? ? D9 05 ? ? ? ? 8B ? ? ? ? ? DD");
+	varPtr = pattern.count(1).get(0).get<uint32_t>(11);
+	ptr_InternalHeightScale = (float*)*varPtr;
+
+	varPtr = pattern.count(1).get(0).get<uint32_t>(17);
+	ptr_RenderHeight = (int*)*varPtr;
 }
 
 void HandleLimits()
@@ -998,6 +1288,27 @@ bool Init()
 	{
 		auto pattern = hook::pattern("75 ? 0F B6 56 ? 52 68 ? ? ? ? 50 50 E8 ? ? ? ? 83 C4 ? 5E 8B 4D ? 33 CD E8 ? ? ? ? 8B E5 5D C3 53");
 		injector::MakeNOP(pattern.get_first(0), 2, true);
+	}
+
+	if (bEnableGCBlur)
+	{
+		// Hook Filter01Render, first block (loop that's ran 4 times + 0.25 pass)
+		auto pattern = hook::pattern("3C 01 0F 85 ? ? ? ? D9 85");
+		uint8_t* filter01_end = pattern.count(1).get(0).get<uint8_t>(4);
+		filter01_end += sizeof(int32_t) + *(int32_t*)filter01_end;
+
+		injector::WriteMemory(pattern.get_first(8), uint8_t(0x56), true); // PUSH ESI (esi = Filter01Params*)
+		injector::MakeCALL(pattern.get_first(9), Filter01Render_Hook1, true);
+		injector::WriteMemory(pattern.get_first(14), uint8_t(0x58), true); // POP EAX (fixes esp)
+		injector::MakeJMP(pattern.get_first(15), filter01_end, true); // JMP over code that was reimplemented
+
+		// Hook Filter01Render second block (loop ran N times depending on AlphaLevel)
+		pattern = hook::pattern("D9 46 ? B9 04 00 00 00 D9");
+
+		injector::WriteMemory(pattern.get_first(0), uint8_t(0x56), true); // PUSH ESI (esi = Filter01Params*)
+		injector::MakeCALL(pattern.get_first(1), Filter01Render_Hook2, true);
+		injector::WriteMemory(pattern.get_first(6), uint8_t(0x58), true); // POP EAX (fixes esp)
+		injector::MakeJMP(pattern.get_first(7), filter01_end, true); // JMP over code that was reimplemented
 	}
 
 	// QTE bindings and icons

--- a/settings/winmm.ini
+++ b/settings/winmm.ini
@@ -23,6 +23,9 @@ FixBlurryImage = true
 ; Disables the film grain overlay that is present in most sections of the game.
 DisableFilmGrain = true
 
+; Whether to enable the original DoF blurring effect from the GC version, which was removed in later ports
+EnableGCBlur = true
+
 ; Whether to use a borderless-window when using windowed-mode
 WindowBorderless = false
 


### PR DESCRIPTION
Added blur fixes from https://github.com/nipkownix/re4_tweaks/issues/5#issuecomment-963766989

Seems to be working across both 1.1.0 & 1.0.6, haven't tried 1.0.6 JP though. Should hopefully match up with the DLL that I posted in that thread, but haven't tried with that many cutscenes yet.

Not sure if there might be a better way to handle the sigs - couldn't sig-scan for the GX funcs themselves since they're all so similar to each other, so had to scan for code that called them instead & find the offset based on the `call` insn, luckily didn't need too much code to handle that though.

I figured `GCBlur` would probably sound better than `DoFBlur` here, but feel free to rename the setting/vars/etc as you like of course!

E: might need to look into increasing the focus-time for binoculars/scope, seems much faster than GC when at 60FPS at least...