### PR TITLE
Add `FixSlowdown` to `FRAME RATE` settings, support for above 60FPS

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -172,6 +172,7 @@ void Settings::ReadSettings()
 	cfg.bRaiseVertexAlloc = iniReader.ReadBoolean("MEMORY", "RaiseVertexAlloc", true);
 	cfg.bRaiseInventoryAlloc = iniReader.ReadBoolean("MEMORY", "RaiseInventoryAlloc", true);
 	cfg.bUseMemcpy = iniReader.ReadBoolean("MEMORY", "UseMemcpy", true);
+    cfg.bFixFPSSlowdown = iniReader.ReadBoolean("FRAME RATE", "FixSlowdown", false);
 	cfg.bIgnoreFPSWarning = iniReader.ReadBoolean("FRAME RATE", "IgnoreFPSWarning", false);
 }
 

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -41,6 +41,7 @@ struct Settings
 	bool bRaiseVertexAlloc;
 	bool bRaiseInventoryAlloc;
 	bool bUseMemcpy;
+	bool bFixFPSSlowdown;
 	bool bIgnoreFPSWarning;
 
 	bool HasUnsavedChanges;

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -101,6 +101,11 @@ RaiseInventoryAlloc = true
 UseMemcpy = true
 
 [FRAME RATE]
+; Experimental: fixes up games DeltaTime related code so that FPS changes should no longer affect game speed
+; also fixes the "new game" option so that setting config.ini's variableframerate above 60 should now work fine - hasn't been tested extensively yet though!
+; (make sure to set IgnoreFPSWarning below to true to allow changing FPS inside config.ini)
+FixSlowdown = false
+
 ; This version of RE4 only works properly if played at 30 or 60 FPS. Anything else can and will cause numerous amounts of
 ; different bugs, most of which aren't even documented. By default, re4_tweaks will warn you about these issues and change
 ; the FPS to either 30 or 60.


### PR DESCRIPTION
Made the fix from https://github.com/nipkownix/re4_tweaks/issues/23#issuecomment-985011951 use signatures, seems to work fine across 1.0.6/1.0.6 debug/1.1.0  😃 

I noticed one thing while testing, seems `maxFrameTime` var shouldn't be kept at 31, looks like it depends on the display / internal framerate (not sure which yet), so for now it's set to `(variableFramerate / 2) + 1`

This means going below half of the variableFramerate setting will still result in slowdown though... hopefully can find some way to detect if user is in the new-game event & only apply this maxFrameTime stuff in that case (or detect if user is in gameplay & make it disable this instead), so we can get rid of all slowdown during gameplay.

I've only added INI setting for it, wasn't sure about adding to UI since I don't think this can be reversed that easily :/

This should probably be tested out a lot before merging, have only really tried out the beginning new-game section with it myself... will probably try a 100Hz run over the weekend, if anyone has a >60Hz monitor please give it a try!