### PR TITLE
Add `DebugMenuKeyCombination` setting, allows custom tool menu key combo

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -5,126 +5,193 @@
 #include "Settings.h"
 #include "settings_string.h"
 
+// tool_menu.cpp
+bool ParseToolMenuKeyCombo(std::string_view in_combo);
+
 Settings cfg;
 
-int Settings::KeyMap(char* key, const char* type)
+struct key_type {
+	int vk;
+	int dik;
+};
+
+std::unordered_map<std::string, key_type> key_map
 {
-	struct key_type {
-		int vk;
-		int dik;
-	};
+	{ "ESCAPE", { 0x1B, 0x01 } },    // Esc
+	{ "0", { 0x30, 0x0B } },    // 0
+	{ "1", { 0x31, 0x02 } },    // 1
+	{ "2", { 0x32, 0x03 } },    // 2
+	{ "3", { 0x33, 0x04 } },    // 3
+	{ "4", { 0x34, 0x05 } },    // 4
+	{ "5", { 0x35, 0x06 } },    // 5
+	{ "6", { 0x36, 0x07 } },    // 6
+	{ "7", { 0x37, 0x08 } },    // 7
+	{ "8", { 0x38, 0x09 } },    // 8
+	{ "9", { 0x39, 0x0A } },    // 9
+	{ "A", { 0x41, 0x1E } },    // A
+	{ "B", { 0x42, 0x30 } },    // B
+	{ "C", { 0x43, 0x2E } },    // C
+	{ "D", { 0x44, 0x20 } },    // D
+	{ "E", { 0x45, 0x12 } },    // E
+	{ "F", { 0x46, 0x21 } },    // F
+	{ "G", { 0x47, 0x22 } },    // G
+	{ "H", { 0x48, 0x23 } },    // H
+	{ "I", { 0x49, 0x17 } },    // I
+	{ "J", { 0x4A, 0x24 } },    // J
+	{ "K", { 0x4B, 0x25 } },    // K
+	{ "L", { 0x4C, 0x26 } },    // L
+	{ "M", { 0x4D, 0x32 } },    // M
+	{ "N", { 0x4E, 0x31 } },    // N
+	{ "O", { 0x4F, 0x18 } },    // O
+	{ "P", { 0x50, 0x19 } },    // P
+	{ "Q", { 0x51, 0x10 } },    // Q
+	{ "R", { 0x52, 0x13 } },    // R
+	{ "S", { 0x53, 0x1F } },    // S
+	{ "T", { 0x54, 0x14 } },    // T
+	{ "U", { 0x55, 0x16 } },    // U
+	{ "V", { 0x56, 0x2F } },    // V
+	{ "W", { 0x57, 0x11 } },    // W
+	{ "X", { 0x58, 0x2D } },    // X
+	{ "Y", { 0x59, 0x15 } },    // Y
+	{ "Z", { 0x5A, 0x2C } },    // Z
+	{ "BACK", { 0x08, 0x0E } },    // Backspace
+	{ "ADD", { 0x6B, 0x4E } },    // Numpad +
+	{ "DECIMAL", { 0x6E, 0x53 } },    // Numpad .
+	{ "DIVIDE", { 0x6F, 0xB5 } },    // Numpad /
+	{ "MULTIPLY", { 0x6A, 0x37 } },    // Numpad *
+	{ "NUMPAD0", { 0x60, 0x52 } },    // Numpad 0
+	{ "NUMPAD1", { 0x61, 0x4F } },    // Numpad 1
+	{ "NUMPAD2", { 0x62, 0x50 } },    // Numpad 2
+	{ "NUMPAD3", { 0x63, 0x51 } },    // Numpad 3
+	{ "NUMPAD4", { 0x64, 0x4B } },    // Numpad 4
+	{ "NUMPAD5", { 0x65, 0x4C } },    // Numpad 5
+	{ "NUMPAD6", { 0x66, 0x4D } },    // Numpad 6
+	{ "NUMPAD7", { 0x67, 0x47 } },    // Numpad 7
+	{ "NUMPAD8", { 0x68, 0x48 } },    // Numpad 8
+	{ "NUMPAD9", { 0x69, 0x49 } },    // Numpad 9
+	{ "OEM_COMMA", { 0xBC, 0x33 } },    // OEM_COMMA (< ,)
+	{ "OEM_MINUS", { 0xBD, 0x0C } },    // OEM_MINUS (_ -)
+	{ "OEM_PERIOD", { 0xBE, 0x34 } },    // OEM_PERIOD (> .)
+	{ "OEM_PLUS", { 0xBB, 0x0D } },    // OEM_PLUS (+ =)
+	{ "<", { 0xBC, 0x33 } },    // OEM_COMMA (< ,)
+	{ ",", { 0xBC, 0x33 } },    // OEM_COMMA (< ,)
+	{ "_", { 0xBD, 0x0C } },    // OEM_MINUS (_ -)
+	{ "-", { 0xBD, 0x0C } },    // OEM_MINUS (_ -)
+	{ ">", { 0xBE, 0x34 } },    // OEM_PERIOD (> .)
+	{ ".", { 0xBE, 0x34 } },    // OEM_PERIOD (> .)
+	{ "+", { 0xBB, 0x0D } },    // OEM_PLUS (+ =)
+	{ "=", { 0xBB, 0x0D } },    // OEM_PLUS (+ =)
+	{ "RETURN", { 0x0D, 0x1C } },    // Enter
+	{ "RENTER", { VK_SEPARATOR, 0 } },    // Enter
+	{ "SPACE", { 0x20, 0x39 } },    // Space
+	{ "SUBTRACT", { 0x6D, 0x4A } },    // Num -
+	{ "TAB", { 0x09, 0x0F } },    // Tab
+	{ "APPS", { 0x5D, 0xDD } },    // Context Menu
+	{ "CAPSLOCK", { 0x14, 0x3A } },    // Caps Lock
+	{ "CONVERT", { 0x1C, 0x79 } },    // Convert
+	{ "UP", { 0x26, 0xC8 } },    // Arrow Up
+	{ "DOWN", { 0x28, 0xD0 } },    // Arrow Down
+	{ "LEFT", { 0x25, 0xCB } },    // Arrow Left
+	{ "RIGHT", { 0x27, 0xCD } },    // Arrow Right
+	{ "F1", { 0x70, 0x3B } },    // F1
+	{ "F2", { 0x71, 0x3C } },    // F2
+	{ "F3", { 0x72, 0x3D } },    // F3
+	{ "F4", { 0x73, 0x3E } },    // F4
+	{ "F5", { 0x74, 0x3F } },    // F5
+	{ "F6", { 0x75, 0x40 } },    // F6
+	{ "F7", { 0x76, 0x41 } },    // F7
+	{ "F8", { 0x77, 0x42 } },    // F8
+	{ "F9", { 0x78, 0x43 } },    // F9
+	{ "F10", { 0x79, 0x44 } },    // F10
+	{ "F11", { 0x7A, 0x57 } },    // F11
+	{ "F12", { 0x7B, 0x58 } },    // F12
+	{ "F13", { 0x7C, 0x64 } },    // F13
+	{ "F14", { 0x7D, 0x65 } },    // F14
+	{ "F15", { 0x7E, 0x66 } },    // F15
+	{ "HOME", { 0x24, 0xC7 } },    // Home
+	{ "INSERT", { 0x2D, 0xD2 } },    // Insert
+	{ "DELETE", { 0x2E, 0xD3 } },    // Delete
+	{ "END", { 0x23, 0xCF } },    // End
+	{ "PAGEUP", { 0x21, 0xC9 } },    // Page Up
+	{ "PAGEDOWN", { 0x22, 0xD1 } },    // Page Down
+	{ "PGUP", { 0x21, 0xC9 } },    // Page Up
+	{ "PGDOWN", { 0x22, 0xD1 } },    // Page Down
+	{ "KANA", { 0x15, 0x70 } },    // Kana
+	{ "KANJI", { 0x19, 0x94 } },    // Kanji
+	{ "LCONTROL", { 0xA2, 0x1D } },    // Left Ctrl
+	{ "LMENU", { 0xA4, 0x38 } },    // Left Alt
+	{ "LSHIFT", { VK_LSHIFT, 0x2A } },    // Left Shift
+	{ "SHIFT", { VK_LSHIFT, 0x2A } },    // Left Shift
+	{ "LWIN", { 0x5B, 0xDB } },    // Left Win
+	{ "NONCONVERT", { 0x1D, 0x7B } },    // Non Convert
+	{ "NUMLOCK", { 0x90, 0x45 } },    // Num Lock
+	{ "PAUSE", { 0x13, 0xC5 } },    // Pause
+	{ "RCONTROL", { 0xA3, 0x9D } },    // Right Ctrl
+	{ "RMENU", { 0xA5, 0xB8 } },    // Right Alt
+	{ "RSHIFT", { 0xA1, 0x36 } },    // Right Shift
+	{ "RWIN", { 0x5C, 0xDC } },    // Right Win
+	{ "SCROLL", { 0x91, 0x46 } },    // Scrol Lock
+	{ "SLEEP", { 0x5F, 0xDF } },    // Sleep
+	{ "PRINTSCR", { 0x2C, 0xB7 } },    // Print Screen
+	{ "CONTROL", { VK_LCONTROL, 0 } },  // Control
+	{ "CTRL", { VK_LCONTROL, 0 } },  // Control
+	{ "LCONTROL", { VK_LCONTROL, 0 } },  // Control
+	{ "LCTRL", { VK_LCONTROL, 0 } },  // Control
+	{ "ALT", { VK_LMENU, 0 } },  // ALT
+	{ "LALT", { VK_LMENU, 0 } },  // ALT
+	{ "RCONTROL", { VK_RCONTROL, 0 } },  // Right Control
+	{ "RCTRL", { VK_RCONTROL, 0 } },  // Right Control
+	{ "ALTGR", { VK_RMENU, 0 } },  // Right ALT
+	{ "RALT", { VK_RMENU, 0 } },  // Right ALT
 
-	std::map<std::string, key_type> key_map;
+	// VKs for localised keyboards
+	{ ";", { VK_OEM_1, 0 } },
+	{ ":", { VK_OEM_1, 0 } },
+	{ "/", { VK_OEM_2, 0 } },
+	{ "?", { VK_OEM_2, 0 } },
+	{ "'", { VK_OEM_3, 0 } }, // UK keyboard
+	{ "@", { VK_OEM_3, 0 } }, // UK keyboard
+	{ "[", { VK_OEM_4, 0 } },
+	{ "{", { VK_OEM_4, 0 } },
+	{ "\\", { VK_OEM_5, 0 } },
+	{ "|", { VK_OEM_5, 0 } },
+	{ "]", { VK_OEM_6, 0 } },
+	{ "}", { VK_OEM_6, 0 } },
+	{ "#", { VK_OEM_7, 0 } },  // UK keyboard
+	{ "\"", { VK_OEM_7, 0 } },
+	{ "`", { VK_OEM_8, 0 } },  // UK keyboard, no idea what this is on US..
 
-	key_map["ESCAPE"]       =   {0x1B, 0x01};    // Esc
-    key_map["0"]            =   {0x30, 0x0B};    // 0
-    key_map["1"]            =   {0x31, 0x02};    // 1
-    key_map["2"]            =   {0x32, 0x03};    // 2
-    key_map["3"]            =   {0x33, 0x04};    // 3
-    key_map["4"]            =   {0x34, 0x05};    // 4
-    key_map["5"]            =   {0x35, 0x06};    // 5
-    key_map["6"]            =   {0x36, 0x07};    // 6
-    key_map["7"]            =   {0x37, 0x08};    // 7
-    key_map["8"]            =   {0x38, 0x09};    // 8
-    key_map["9"]            =   {0x39, 0x0A};    // 9
-    key_map["A"]            =   {0x41, 0x1E};    // A
-    key_map["B"]            =   {0x42, 0x30};    // B
-    key_map["C"]            =   {0x43, 0x2E};    // C
-    key_map["D"]            =   {0x44, 0x20};    // D
-    key_map["E"]            =   {0x45, 0x12};    // E
-    key_map["F"]            =   {0x46, 0x21};    // F
-    key_map["G"]            =   {0x47, 0x22};    // G
-    key_map["H"]            =   {0x48, 0x23};    // H
-    key_map["I"]            =   {0x49, 0x17};    // I
-    key_map["J"]            =   {0x4A, 0x24};    // J
-    key_map["K"]            =   {0x4B, 0x25};    // K
-    key_map["L"]            =   {0x4C, 0x26};    // L
-    key_map["M"]            =   {0x4D, 0x32};    // M
-    key_map["N"]            =   {0x4E, 0x31};    // N
-    key_map["O"]            =   {0x4F, 0x18};    // O
-    key_map["P"]            =   {0x50, 0x19};    // P
-    key_map["Q"]            =   {0x51, 0x10};    // Q
-    key_map["R"]            =   {0x52, 0x13};    // R
-    key_map["S"]            =   {0x53, 0x1F};    // S
-    key_map["T"]            =   {0x54, 0x14};    // T
-    key_map["U"]            =   {0x55, 0x16};    // U
-    key_map["V"]            =   {0x56, 0x2F};    // V
-    key_map["W"]            =   {0x57, 0x11};    // W
-    key_map["X"]            =   {0x58, 0x2D};    // X
-    key_map["Y"]            =   {0x59, 0x15};    // Y
-    key_map["Z"]            =   {0x5A, 0x2C};    // Z
-    key_map["BACK"]         =   {0x08, 0x0E};    // Backspace
-    key_map["ADD"]          =   {0x6B, 0x4E};    // Numpad +
-    key_map["DECIMAL"]      =   {0x6E, 0x53};    // Numpad .
-    key_map["DIVIDE"]       =   {0x6F, 0xB5};    // Numpad /
-    key_map["MULTIPLY"]     =   {0x6A, 0x37};    // Numpad *
-    key_map["NUMPAD0"]      =   {0x60, 0x52};    // Numpad 0
-    key_map["NUMPAD1"]      =   {0x61, 0x4F};    // Numpad 1
-    key_map["NUMPAD2"]      =   {0x62, 0x50};    // Numpad 2
-    key_map["NUMPAD3"]      =   {0x63, 0x51};    // Numpad 3
-    key_map["NUMPAD4"]      =   {0x64, 0x4B};    // Numpad 4
-    key_map["NUMPAD5"]      =   {0x65, 0x4C};    // Numpad 5
-    key_map["NUMPAD6"]      =   {0x66, 0x4D};    // Numpad 6
-    key_map["NUMPAD7"]      =   {0x67, 0x47};    // Numpad 7
-    key_map["NUMPAD8"]      =   {0x68, 0x48};    // Numpad 8
-    key_map["NUMPAD9"]      =   {0x69, 0x49};    // Numpad 9
-    key_map["OEM_COMMA"]    =   {0xBC, 0x33};    // OEM_COMMA (< ,)
-    key_map["OEM_MINUS"]    =   {0xBD, 0x0C};    // OEM_MINUS (_ -)
-    key_map["OEM_PERIOD"]   =   {0xBE, 0x34};    // OEM_PERIOD (> .)
-    key_map["OEM_PLUS"]     =   {0xBB, 0x0D};    // OEM_PLUS (+ =)
-    key_map["RETURN"]       =   {0x0D, 0x1C};    // Enter
-    key_map["SPACE"]        =   {0x20, 0x39};    // Space
-    key_map["SUBTRACT"]     =   {0x6D, 0x4A};    // Num -
-    key_map["TAB"]          =   {0x09, 0x0F};    // Tab
-    key_map["APPS"]         =   {0x5D, 0xDD};    // Context Menu
-    key_map["CAPSLOCK"]     =   {0x14, 0x3A};    // Caps Lock
-    key_map["CONVERT"]      =   {0x1C, 0x79};    // Convert
-    key_map["UP"]           =   {0x26, 0xC8};    // Arrow Up
-    key_map["DOWN"]         =   {0x28, 0xD0};    // Arrow Down
-    key_map["LEFT"]         =   {0x25, 0xCB};    // Arrow Left
-    key_map["RIGHT"]        =   {0x27, 0xCD};    // Arrow Right
-    key_map["F1"]           =   {0x70, 0x3B};    // F1
-    key_map["F2"]           =   {0x71, 0x3C};    // F2
-    key_map["F3"]           =   {0x72, 0x3D};    // F3
-    key_map["F4"]           =   {0x73, 0x3E};    // F4
-    key_map["F5"]           =   {0x74, 0x3F};    // F5
-    key_map["F6"]           =   {0x75, 0x40};    // F6
-    key_map["F7"]           =   {0x76, 0x41};    // F7
-    key_map["F8"]           =   {0x77, 0x42};    // F8
-    key_map["F9"]           =   {0x78, 0x43};    // F9
-    key_map["F10"]          =   {0x79, 0x44};    // F10
-    key_map["F11"]          =   {0x7A, 0x57};    // F11
-    key_map["F12"]          =   {0x7B, 0x58};    // F12
-    key_map["F13"]          =   {0x7C, 0x64};    // F13
-    key_map["F14"]          =   {0x7D, 0x65};    // F14
-    key_map["F15"]          =   {0x7E, 0x66};    // F15
-    key_map["HOME"]         =   {0x24, 0xC7};    // Home
-    key_map["INSERT"]       =   {0x2D, 0xD2};    // Insert
-    key_map["DELETE"]       =   {0x2E, 0xD3};    // Delete
-    key_map["END"]          =   {0x23, 0xCF};    // End
-    key_map["PAGEUP"]       =   {0x21, 0xC9};    // Page Up
-    key_map["PAGEDOWN"]     =   {0x22, 0xD1};    // Page Down
-    key_map["KANA"]         =   {0x15, 0x70};    // Kana
-    key_map["KANJI"]        =   {0x19, 0x94};    // Kanji
-    key_map["LCONTROL"]     =   {0xA2, 0x1D};    // Left Ctrl
-    key_map["LMENU"]        =   {0xA4, 0x38};    // Left Alt
-    key_map["LSHIFT"]       =   {0xA0, 0x2A};    // Left Shift
-    key_map["LWIN"]         =   {0x5B, 0xDB};    // Left Win
-    key_map["NONCONVERT"]   =   {0x1D, 0x7B};    // Non Convert
-    key_map["NUMLOCK"]      =   {0x90, 0x45};    // Num Lock
-    key_map["PAUSE"]        =   {0x13, 0xC5};    // Pause
-    key_map["RCONTROL"]     =   {0xA3, 0x9D};    // Right Ctrl
-    key_map["RMENU"]        =   {0xA5, 0xB8};    // Right Alt
-    key_map["RSHIFT"]       =   {0xA1, 0x36};    // Right Shift
-    key_map["RWIN"]         =   {0x5C, 0xDC};    // Right Win
-    key_map["SCROLL"]       =   {0x91, 0x46};    // Scrol Lock
-    key_map["SLEEP"]        =   {0x5F, 0xDF};    // Sleep
-    key_map["PRINTSCR"]     =   {0x2C, 0xB7};    // Print Screen
+	// Similar names to aid in parsing user data
+	{ "ESC", { 0x1B, 0x01 } },    // Esc
+	{ "BACKSPACE", { 0x08, 0x0E } },    // Backspace
+	{ "BKSP", { 0x08, 0x0E } },    // Backspace
+	{ "NUM+", { 0x6B, 0x4E } },    // Numpad +
+	{ "NUM-", { 0x6E, 0x53 } },    // Numpad .
+	{ "NUM/", { 0x6F, 0xB5 } },    // Numpad /
+	{ "NUM*", { 0x6A, 0x37 } },    // Numpad *
+	{ "NUM0", { 0x60, 0x52 } },    // Numpad 0
+	{ "NUM1", { 0x61, 0x4F } },    // Numpad 1
+	{ "NUM2", { 0x62, 0x50 } },    // Numpad 2
+	{ "NUM3", { 0x63, 0x51 } },    // Numpad 3
+	{ "NUM4", { 0x64, 0x4B } },    // Numpad 4
+	{ "NUM5", { 0x65, 0x4C } },    // Numpad 5
+	{ "NUM6", { 0x66, 0x4D } },    // Numpad 6
+	{ "NUM7", { 0x67, 0x47 } },    // Numpad 7
+	{ "NUM8", { 0x68, 0x48 } },    // Numpad 8
+	{ "NUM9", { 0x69, 0x49 } },    // Numpad 9
+	{ "ENTER", { 0x0D, 0x1C } },    // Enter
+	{ "DEL", { 0x2E, 0xD3 } },    // Delete
+};
 
-	if (type == "vk")
+int Settings::KeyMap(const char* key, bool get_vk)
+{
+	if (!key_map.count(key))
+		return 0;
+
+	if (get_vk)
 		return key_map[key].vk;
-	else
-		return key_map[key].dik;
+
+	return key_map[key].dik;
 }
 
 void Settings::ReadSettings()
@@ -159,6 +226,7 @@ void Settings::ReadSettings()
 	cfg.bFixQTE = iniReader.ReadBoolean("MISC", "FixQTE", true);
 	cfg.bSkipIntroLogos = iniReader.ReadBoolean("MISC", "SkipIntroLogos", false);
 	cfg.bEnableDebugMenu = iniReader.ReadBoolean("MISC", "EnableDebugMenu", false);
+	cfg.sDebugMenuKeyCombo = iniReader.ReadString("MISC", "DebugMenuKeyCombination", "CTRL+F3"); // if default changed, make sure to edit tool_menu.cpp!toolMenuKeyCombo vector!
     cfg.bUseMouseTurning = iniReader.ReadBoolean("MOUSE", "UseMouseTurning", true);
     cfg.fTurnSensitivity = iniReader.ReadFloat("MOUSE", "TurnSensitivity", 1.0f);
 	cfg.bFixSniperZoom = iniReader.ReadBoolean("MOUSE", "FixSniperZoom", true);
@@ -174,6 +242,9 @@ void Settings::ReadSettings()
 	cfg.bRaiseInventoryAlloc = iniReader.ReadBoolean("MEMORY", "RaiseInventoryAlloc", true);
 	cfg.bUseMemcpy = iniReader.ReadBoolean("MEMORY", "UseMemcpy", true);
 	cfg.bIgnoreFPSWarning = iniReader.ReadBoolean("FRAME RATE", "IgnoreFPSWarning", false);
+
+	if (cfg.sDebugMenuKeyCombo.length())
+		ParseToolMenuKeyCombo(sDebugMenuKeyCombo);
 }
 
 void Settings::WriteSettings()
@@ -211,6 +282,7 @@ void Settings::WriteSettings()
 	iniReader.WriteBoolean("MISC", "FixQTE", cfg.bFixQTE);
 	iniReader.WriteBoolean("MISC", "SkipIntroLogos", cfg.bSkipIntroLogos);
 	iniReader.WriteBoolean("MISC", "EnableDebugMenu", cfg.bEnableDebugMenu);
+	iniReader.WriteString("MISC", "DebugMenuKeyCombination", cfg.sDebugMenuKeyCombo);
 	iniReader.WriteBoolean("MOUSE", "FixSniperZoom", cfg.bFixSniperZoom);
 	iniReader.WriteBoolean("MOUSE", "FixRetryLoadMouseSelector", cfg.bFixRetryLoadMouseSelector);
 	iniReader.WriteString("KEYBOARD", "flip_item_up", " " + cfg.flip_item_up);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -18,6 +18,7 @@ struct key_type {
 std::unordered_map<std::string, key_type> key_map
 {
 	{ "ESCAPE", { 0x1B, 0x01 } },    // Esc
+	{ "ESC", { 0x1B, 0x01 } },    // Esc
 	{ "0", { 0x30, 0x0B } },    // 0
 	{ "1", { 0x31, 0x02 } },    // 1
 	{ "2", { 0x32, 0x03 } },    // 2
@@ -55,10 +56,18 @@ std::unordered_map<std::string, key_type> key_map
 	{ "Y", { 0x59, 0x15 } },    // Y
 	{ "Z", { 0x5A, 0x2C } },    // Z
 	{ "BACK", { 0x08, 0x0E } },    // Backspace
+	{ "BACKSPACE", { 0x08, 0x0E } },    // Backspace
+	{ "BKSP", { 0x08, 0x0E } },    // Backspace
 	{ "ADD", { 0x6B, 0x4E } },    // Numpad +
+	{ "NUM+", { 0x6B, 0x4E } },    // Numpad +
 	{ "DECIMAL", { 0x6E, 0x53 } },    // Numpad .
+	{ "NUM.", { 0x6E, 0x53 } },    // Numpad .
 	{ "DIVIDE", { 0x6F, 0xB5 } },    // Numpad /
+	{ "NUM/", { 0x6F, 0xB5 } },    // Numpad /
 	{ "MULTIPLY", { 0x6A, 0x37 } },    // Numpad *
+	{ "NUM*", { 0x6A, 0x37 } },    // Numpad *
+	{ "SUBTRACT", { 0x6D, 0x4A } },    // Numpad -
+	{ "NUM-", { 0x6D, 0x4A } },    // Numpad -
 	{ "NUMPAD0", { 0x60, 0x52 } },    // Numpad 0
 	{ "NUMPAD1", { 0x61, 0x4F } },    // Numpad 1
 	{ "NUMPAD2", { 0x62, 0x50 } },    // Numpad 2
@@ -69,6 +78,16 @@ std::unordered_map<std::string, key_type> key_map
 	{ "NUMPAD7", { 0x67, 0x47 } },    // Numpad 7
 	{ "NUMPAD8", { 0x68, 0x48 } },    // Numpad 8
 	{ "NUMPAD9", { 0x69, 0x49 } },    // Numpad 9
+	{ "NUM0", { 0x60, 0x52 } },    // Numpad 0
+	{ "NUM1", { 0x61, 0x4F } },    // Numpad 1
+	{ "NUM2", { 0x62, 0x50 } },    // Numpad 2
+	{ "NUM3", { 0x63, 0x51 } },    // Numpad 3
+	{ "NUM4", { 0x64, 0x4B } },    // Numpad 4
+	{ "NUM5", { 0x65, 0x4C } },    // Numpad 5
+	{ "NUM6", { 0x66, 0x4D } },    // Numpad 6
+	{ "NUM7", { 0x67, 0x47 } },    // Numpad 7
+	{ "NUM8", { 0x68, 0x48 } },    // Numpad 8
+	{ "NUM9", { 0x69, 0x49 } },    // Numpad 9
 	{ "OEM_COMMA", { 0xBC, 0x33 } },    // OEM_COMMA (< ,)
 	{ "OEM_MINUS", { 0xBD, 0x0C } },    // OEM_MINUS (_ -)
 	{ "OEM_PERIOD", { 0xBE, 0x34 } },    // OEM_PERIOD (> .)
@@ -82,9 +101,9 @@ std::unordered_map<std::string, key_type> key_map
 	{ "+", { 0xBB, 0x0D } },    // OEM_PLUS (+ =)
 	{ "=", { 0xBB, 0x0D } },    // OEM_PLUS (+ =)
 	{ "RETURN", { 0x0D, 0x1C } },    // Enter
-	{ "RENTER", { VK_SEPARATOR, 0 } },    // Enter
+	{ "ENTER", { 0x0D, 0x1C } },    // Enter
+	{ "RENTER", { 0x6C, 0 } },    // Right/Numpad Enter
 	{ "SPACE", { 0x20, 0x39 } },    // Space
-	{ "SUBTRACT", { 0x6D, 0x4A } },    // Num -
 	{ "TAB", { 0x09, 0x0F } },    // Tab
 	{ "APPS", { 0x5D, 0xDD } },    // Context Menu
 	{ "CAPSLOCK", { 0x14, 0x3A } },    // Caps Lock
@@ -111,6 +130,7 @@ std::unordered_map<std::string, key_type> key_map
 	{ "HOME", { 0x24, 0xC7 } },    // Home
 	{ "INSERT", { 0x2D, 0xD2 } },    // Insert
 	{ "DELETE", { 0x2E, 0xD3 } },    // Delete
+	{ "DEL", { 0x2E, 0xD3 } },    // Delete
 	{ "END", { 0x23, 0xCF } },    // End
 	{ "PAGEUP", { 0x21, 0xC9 } },    // Page Up
 	{ "PAGEDOWN", { 0x22, 0xD1 } },    // Page Down
@@ -119,68 +139,45 @@ std::unordered_map<std::string, key_type> key_map
 	{ "KANA", { 0x15, 0x70 } },    // Kana
 	{ "KANJI", { 0x19, 0x94 } },    // Kanji
 	{ "LCONTROL", { 0xA2, 0x1D } },    // Left Ctrl
+	{ "CONTROL", { 0xA2, 0x1D } },  // Left Ctrl
+	{ "CTRL", { 0xA2, 0x1D } },  // Left Ctrl
+	{ "LCTRL", { 0xA2, 0x1D } },  // Left Ctrl
 	{ "LMENU", { 0xA4, 0x38 } },    // Left Alt
-	{ "LSHIFT", { VK_LSHIFT, 0x2A } },    // Left Shift
-	{ "SHIFT", { VK_LSHIFT, 0x2A } },    // Left Shift
+	{ "ALT", { 0xA4, 0x38 } },  // Left Alt
+	{ "LALT", { 0xA4, 0x38 } },  // Left Alt
+	{ "LSHIFT", { 0xA0, 0x2A } },    // Left Shift
+	{ "SHIFT", { 0xA0, 0x2A } },    // Left Shift
 	{ "LWIN", { 0x5B, 0xDB } },    // Left Win
 	{ "NONCONVERT", { 0x1D, 0x7B } },    // Non Convert
 	{ "NUMLOCK", { 0x90, 0x45 } },    // Num Lock
 	{ "PAUSE", { 0x13, 0xC5 } },    // Pause
 	{ "RCONTROL", { 0xA3, 0x9D } },    // Right Ctrl
+	{ "RCTRL", { 0xA3, 0x9D } },  // Right Ctrl
 	{ "RMENU", { 0xA5, 0xB8 } },    // Right Alt
+	{ "ALTGR", { 0xA5, 0xB8 } },  // Right Alt
+	{ "RALT", { 0xA5, 0xB8 } },  // Right Alt
 	{ "RSHIFT", { 0xA1, 0x36 } },    // Right Shift
 	{ "RWIN", { 0x5C, 0xDC } },    // Right Win
 	{ "SCROLL", { 0x91, 0x46 } },    // Scrol Lock
 	{ "SLEEP", { 0x5F, 0xDF } },    // Sleep
 	{ "PRINTSCR", { 0x2C, 0xB7 } },    // Print Screen
-	{ "CONTROL", { VK_LCONTROL, 0 } },  // Control
-	{ "CTRL", { VK_LCONTROL, 0 } },  // Control
-	{ "LCONTROL", { VK_LCONTROL, 0 } },  // Control
-	{ "LCTRL", { VK_LCONTROL, 0 } },  // Control
-	{ "ALT", { VK_LMENU, 0 } },  // ALT
-	{ "LALT", { VK_LMENU, 0 } },  // ALT
-	{ "RCONTROL", { VK_RCONTROL, 0 } },  // Right Control
-	{ "RCTRL", { VK_RCONTROL, 0 } },  // Right Control
-	{ "ALTGR", { VK_RMENU, 0 } },  // Right ALT
-	{ "RALT", { VK_RMENU, 0 } },  // Right ALT
 
 	// VKs for localised keyboards
-	{ ";", { VK_OEM_1, 0 } },
-	{ ":", { VK_OEM_1, 0 } },
-	{ "/", { VK_OEM_2, 0 } },
-	{ "?", { VK_OEM_2, 0 } },
+	{ ";", { VK_OEM_1, 0x27 } },
+	{ ":", { VK_OEM_1, 0x27 } },
+	{ "/", { VK_OEM_2, 0x35 } },
+	{ "?", { VK_OEM_2, 0x35 } },
 	{ "'", { VK_OEM_3, 0 } }, // UK keyboard
 	{ "@", { VK_OEM_3, 0 } }, // UK keyboard
-	{ "[", { VK_OEM_4, 0 } },
-	{ "{", { VK_OEM_4, 0 } },
-	{ "\\", { VK_OEM_5, 0 } },
-	{ "|", { VK_OEM_5, 0 } },
-	{ "]", { VK_OEM_6, 0 } },
-	{ "}", { VK_OEM_6, 0 } },
+	{ "[", { VK_OEM_4, 0x1A } },
+	{ "{", { VK_OEM_4, 0x1A } },
+	{ "\\", { VK_OEM_5, 0x2B } },
+	{ "|", { VK_OEM_5, 0x2B } },
+	{ "]", { VK_OEM_6, 0x1B } },
+	{ "}", { VK_OEM_6, 0x1B } },
 	{ "#", { VK_OEM_7, 0 } },  // UK keyboard
-	{ "\"", { VK_OEM_7, 0 } },
-	{ "`", { VK_OEM_8, 0 } },  // UK keyboard, no idea what this is on US..
-
-	// Similar names to aid in parsing user data
-	{ "ESC", { 0x1B, 0x01 } },    // Esc
-	{ "BACKSPACE", { 0x08, 0x0E } },    // Backspace
-	{ "BKSP", { 0x08, 0x0E } },    // Backspace
-	{ "NUM+", { 0x6B, 0x4E } },    // Numpad +
-	{ "NUM-", { 0x6E, 0x53 } },    // Numpad .
-	{ "NUM/", { 0x6F, 0xB5 } },    // Numpad /
-	{ "NUM*", { 0x6A, 0x37 } },    // Numpad *
-	{ "NUM0", { 0x60, 0x52 } },    // Numpad 0
-	{ "NUM1", { 0x61, 0x4F } },    // Numpad 1
-	{ "NUM2", { 0x62, 0x50 } },    // Numpad 2
-	{ "NUM3", { 0x63, 0x51 } },    // Numpad 3
-	{ "NUM4", { 0x64, 0x4B } },    // Numpad 4
-	{ "NUM5", { 0x65, 0x4C } },    // Numpad 5
-	{ "NUM6", { 0x66, 0x4D } },    // Numpad 6
-	{ "NUM7", { 0x67, 0x47 } },    // Numpad 7
-	{ "NUM8", { 0x68, 0x48 } },    // Numpad 8
-	{ "NUM9", { 0x69, 0x49 } },    // Numpad 9
-	{ "ENTER", { 0x0D, 0x1C } },    // Enter
-	{ "DEL", { 0x2E, 0xD3 } },    // Delete
+	{ "\"", { VK_OEM_7, 0 } }, // UK keyboard
+	{ "`", { VK_OEM_8, 0 } },  // UK keyboard
 };
 
 int Settings::KeyMap(const char* key, bool get_vk)

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -8,7 +8,7 @@ struct Settings
 {
 	int Tab = 0;
 
-	int KeyMap(char* key, const char* type);
+	int KeyMap(const char* key, bool get_vk);
 
 	// Those save
 	float fFOVAdditional;
@@ -29,6 +29,7 @@ struct Settings
 	bool bFixQTE;
 	bool bSkipIntroLogos;
 	bool bEnableDebugMenu;
+	std::string sDebugMenuKeyCombo;
 	bool bUseMouseTurning;
 	float fTurnSensitivity;
 	bool bFixSniperZoom;

--- a/dllmain/WndProcHook.cpp
+++ b/dllmain/WndProcHook.cpp
@@ -54,12 +54,12 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	switch (uMsg) {
 		case WM_KEYDOWN:
-			if (wParam == cfg.KeyMap(cfg.flip_item_left.data(), "vk") || wParam == cfg.KeyMap(cfg.flip_item_right.data(), "vk"))
+			if (wParam == cfg.KeyMap(cfg.flip_item_left.data(), true) || wParam == cfg.KeyMap(cfg.flip_item_right.data(), true))
 			{
 				bShouldFlipX = true;
 				Sleep(1);
 			}
-			else if (wParam == cfg.KeyMap(cfg.flip_item_up.data(), "vk") || wParam == cfg.KeyMap(cfg.flip_item_down.data(), "vk"))
+			else if (wParam == cfg.KeyMap(cfg.flip_item_up.data(), true) || wParam == cfg.KeyMap(cfg.flip_item_down.data(), true))
 			{
 				bShouldFlipY = true;
 				Sleep(1);

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -309,8 +309,7 @@ void Init_Main()
 	if (cfg.bEnableDebugMenu)
 	{
 		Init_ToolMenu();
-		if (bisDebugBuild)
-			Init_ToolMenuDebug();
+		Init_ToolMenuDebug(); // mostly hooks for debug-build tool menu, but also includes hooks to slow down selection cursor
 	}
 }
 

--- a/dllmain/qtefixes.cpp
+++ b/dllmain/qtefixes.cpp
@@ -29,7 +29,7 @@ float fQTESpeedMult = 1.5f;
 // QTE Key 1 icons
 void __declspec(naked) KEY_1_icon1()
 {
-	intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), "dik");
+	intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), false);
 	_asm
 	{
 		lea edx, [ebp - 0x3B4]
@@ -40,7 +40,7 @@ void __declspec(naked) KEY_1_icon1()
 
 void __declspec(naked) KEY_1_icon2()
 {
-	intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), "dik");
+	intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), false);
 	_asm
 	{
 		lea ecx, [ebp - 0x4CC]
@@ -51,7 +51,7 @@ void __declspec(naked) KEY_1_icon2()
 
 void __declspec(naked) KEY_1_icon3()
 {
-	intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), "dik");
+	intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), false);
 	_asm
 	{
 		lea ecx, [ebp - 0x280]
@@ -64,7 +64,7 @@ void __declspec(naked) KEY_1_icon3()
 
 void __declspec(naked) KEY_2_icon1()
 {
-	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), "dik");
+	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), false);
 	_asm
 	{
 		lea ecx, [ebp - 0x37C]
@@ -75,7 +75,7 @@ void __declspec(naked) KEY_2_icon1()
 
 void __declspec(naked) KEY_2_icon2()
 {
-	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), "dik");
+	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), false);
 	_asm
 	{
 		lea ecx, [ebp - 0x76C]
@@ -86,7 +86,7 @@ void __declspec(naked) KEY_2_icon2()
 
 void __declspec(naked) KEY_2_icon3()
 {
-	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), "dik");
+	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), false);
 	_asm
 	{
 		lea edx, [ebp - 0x494]
@@ -97,7 +97,7 @@ void __declspec(naked) KEY_2_icon3()
 
 void __declspec(naked) KEY_2_icon4()
 {
-	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), "dik");
+	intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), false);
 	_asm
 	{
 		lea ecx, [ebp - 0x2F0]
@@ -174,7 +174,7 @@ void Init_QTEfixes()
 	{
 		void operator()(injector::reg_pack& regs)
 		{
-			intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), "dik");
+			intQTE_key_1 = cfg.KeyMap(cfg.QTE_key_1.data(), false);
 			regs.ebx = intQTE_key_1;
 			regs.eax = *(int32_t*)(regs.eax + 0x1C);
 		}
@@ -186,7 +186,7 @@ void Init_QTEfixes()
 	{
 		void operator()(injector::reg_pack& regs)
 		{
-			intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), "dik");
+			intQTE_key_2 = cfg.KeyMap(cfg.QTE_key_2.data(), false);
 			regs.edx = intQTE_key_2;
 			regs.eax = *(int32_t*)(regs.eax + 0x1C);
 		}

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -60,6 +60,11 @@ SkipIntroLogos = false
 ; (may have a rare chance to cause a heap corruption crash when loading a save, but if the game loads fine then there shouldn't be any chance of crashing)
 EnableDebugMenu = false
 
+; Keyboard key-combination to make the "tool menu" debug menu appear
+; All keys can be combined (requiring multiple to be pressed at the same time) by using + symbol between key names
+; (see top of Settings.cpp file for possible key names to use)
+DebugMenuKeyCombination = CTRL+F3
+
 [MOUSE]
 ; Makes it so the mouse turns the character instead of controlling the camera.
 ; "Modern" aiming mode in the game's settings is recomended.


### PR DESCRIPTION
New default for tool menu is now `CTRL+F3`, as not all keyboards have HOME+END, and F1/F2 are used by Imgui things - the combo string will be parsed into a std::vector, which the tool-menu hook iterates over to check if all keys are pressed.

(the combo uses multiple keys to reduce chance of it being pressed by accident, don't want people to get stuck in the tool-menu mode...)

This also changes Setting.cpp so that `key_map` is defined statically (afaik previously it looked like key_map was inited each time KeyMap got called), and changed the `char* type` KeyMap param to a bool instead to get rid of a string compare.

Also added some key name variants to key_map to improve chance of users combo string getting parsed, there were a couple keys that I added to key_map but don't know the DIK of tho, what does DIK mean anyway? DirectInput key or something?

E: build here if anyone wants to test it:
[winmm.zip](https://github.com/nipkownix/re4_tweaks/files/7820502/winmm.zip)

E2: DIKless keycodes:
- RENTER (numpad enter key, i think)
- CONTROL/LCONTROL/CTRL/LCTRL
- ALT/LALT
- RCONTROL/RCTRL
- ALTGR/RALT (AltGr is UK keyboard name for right alt key)
- ;
- :
- /
- ?
- '
- @
- [
- {
- \
- |
- ]
- }
- \#
- "
- `
 
The symbols there are mostly VK_OEM_* keys, I only really know the OEM symbols for my UK keyboard, which are what I added there, if someone has US keyboard it'd be good if you can try finding what symbols match up to VK_OEM_1/OEM_2/etc.
Not sure if those symbols have DIKs for us to add in there neither, the tool menu stuff doesn't need any DIK though so not a big deal there, maybe worth adding for the hooks that do use it though.