### PR TITLE
`AshleyJPCameraAngles`: unlocks classic camera during Ashley segment

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -219,11 +219,12 @@ void Settings::ReadSettings()
 	cfg.bRememberWindowPos = iniReader.ReadBoolean("DISPLAY", "RememberWindowPos", false);
 	cfg.b60fpsFixes = iniReader.ReadBoolean("MISC", "60fpsFixes", true);
 	cfg.bFixQTE = iniReader.ReadBoolean("MISC", "FixQTE", true);
+	cfg.bAshleyJPCameraAngles = iniReader.ReadBoolean("MISC", "AshleyJPCameraAngles", false);
 	cfg.bSkipIntroLogos = iniReader.ReadBoolean("MISC", "SkipIntroLogos", false);
 	cfg.bEnableDebugMenu = iniReader.ReadBoolean("MISC", "EnableDebugMenu", false);
 	cfg.sDebugMenuKeyCombo = iniReader.ReadString("MISC", "DebugMenuKeyCombination", "CTRL+F3"); // if default changed, make sure to edit tool_menu.cpp!toolMenuKeyCombo vector!
-    cfg.bUseMouseTurning = iniReader.ReadBoolean("MOUSE", "UseMouseTurning", true);
-    cfg.fTurnSensitivity = iniReader.ReadFloat("MOUSE", "TurnSensitivity", 1.0f);
+	cfg.bUseMouseTurning = iniReader.ReadBoolean("MOUSE", "UseMouseTurning", true);
+	cfg.fTurnSensitivity = iniReader.ReadFloat("MOUSE", "TurnSensitivity", 1.0f);
 	cfg.bFixSniperZoom = iniReader.ReadBoolean("MOUSE", "FixSniperZoom", true);
 	cfg.bFixRetryLoadMouseSelector = iniReader.ReadBoolean("MOUSE", "FixRetryLoadMouseSelector", true);
 	cfg.flip_item_up = iniReader.ReadString("KEYBOARD", "flip_item_up", "HOME");
@@ -282,6 +283,7 @@ void Settings::WriteSettings()
 	iniReader.WriteInteger("DISPLAY", "WindowPositionY", cfg.iWindowPositionY);
 	iniReader.WriteBoolean("DISPLAY", "RememberWindowPos", cfg.bRememberWindowPos);
 	iniReader.WriteBoolean("MISC", "FixQTE", cfg.bFixQTE);
+	iniReader.WriteBoolean("MISC", "AshleyJPCameraAngles", cfg.bAshleyJPCameraAngles);
 	iniReader.WriteBoolean("MISC", "SkipIntroLogos", cfg.bSkipIntroLogos);
 	iniReader.WriteBoolean("MISC", "EnableDebugMenu", cfg.bEnableDebugMenu);
 	iniReader.WriteString("MISC", "DebugMenuKeyCombination", cfg.sDebugMenuKeyCombo);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -21,6 +21,7 @@ struct Settings
 	bool bDisableFilmGrain;
 	bool bEnableGCBlur;
 	bool bEnableGCScopeBlur;
+	bool bAshleyJPCameraAngles;
 	bool bWindowBorderless;
 	int iWindowPositionX;
 	int iWindowPositionY;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -294,6 +294,14 @@ void MenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				// AshleyJPCameraAngles
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("AshleyJPCameraAngles", &cfg.bAshleyJPCameraAngles);
+				ImGui::TextWrapped("Unlocks the JP-only classic camera angles during Ashley segment.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// SkipIntroLogos
 				cfg.HasUnsavedChanges |= ImGui::Checkbox("SkipIntroLogos", &cfg.bSkipIntroLogos);
 				ImGui::TextWrapped("Whether to skip the Capcom etc intro logos when starting the game.");

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -51,6 +51,9 @@ RememberWindowPos = false
 ; This fix makes QTEs that involve rapid button presses much more forgiving.
 FixQTE = true
 
+; Unlocks the JP-only classic camera angles during Ashley segment.
+AshleyJPCameraAngles = false
+
 ; Whether to skip the Capcom etc intro logos when starting the game.
 SkipIntroLogos = false
 


### PR DESCRIPTION
This is done with a MakeInline hook (at 0x6F5518 in 1.1.0, sig also works for 1.0.6), so that it can be toggled while in-game fine (hopefully game won't have any issue with this getting switched about...)

I haven't really used MakeInline much before, so there's likely a better way to handle this.

Tested with 1.1.0, 1.0.6 & 1.0.6 debug, would be a good idea to check if JP version still works too though.

If anyone has a better name than `UnlockJPOnly` feel free to post it too!