### PR TITLE
Check if EXE is 4GB patched, prompt user & allow patching if not

### DIFF
--- a/dllmain/ConsoleWnd.h
+++ b/dllmain/ConsoleWnd.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 struct ConsoleOutput
 {
 	void ShowConsoleOutput();

--- a/dllmain/LAApatch.cpp
+++ b/dllmain/LAApatch.cpp
@@ -1,0 +1,157 @@
+#include <iostream>
+#include "..\includes\stdafx.h"
+#include <d3d9.h>
+#include "dllmain.h"
+#include "Settings.h"
+#include "ConsoleWnd.h"
+#include "LAApatch.h"
+#include "..\external\imgui\imgui.h"
+#include "..\external\imgui\imgui_impl_win32.h"
+#include "..\external\imgui\imgui_impl_dx9.h"
+
+LAApatch laa;
+
+bool LAApatch::GameIsLargeAddressAware()
+{
+	static PBYTE module_base = reinterpret_cast<PBYTE>(GetModuleHandle(nullptr));
+
+	PIMAGE_DOS_HEADER dos_header = reinterpret_cast<PIMAGE_DOS_HEADER>(module_base);
+	PIMAGE_NT_HEADERS nt_headers = reinterpret_cast<PIMAGE_NT_HEADERS>(module_base + dos_header->e_lfanew);
+
+	return (nt_headers->FileHeader.Characteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) == IMAGE_FILE_LARGE_ADDRESS_AWARE;
+}
+
+LAADialogState LAA_State = LAADialogState::NotShowing;
+int LAA_ErrorNum = 0;
+void LAApatch::LAARender()
+{
+	if (GameIsLargeAddressAware())
+	{
+		// Exit out in case we needlessly ended up here somehow
+		LAA_State = LAADialogState::NotShowing;
+		return;
+	}
+
+	ImGuiIO& io = ImGui::GetIO();
+
+	if (LAA_State == LAADialogState::Showing)
+	{
+		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSizeConstraints(ImVec2(400, 175), ImVec2(400, 175));
+		ImGui::Begin("4GB / Large Address Aware patch missing!");
+		ImGui::TextWrapped("Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory.\n\nDo you want re4_tweaks to patch the game EXE for you? (requires relaunch!)");
+
+		ImGui::Spacing();
+		ImGui::SetCursorPosX(ImGui::GetWindowWidth() - 225);
+
+		if (ImGui::Button("Yes", ImVec2(104, 35)))
+		{
+			char module_path_array[4096];
+			GetModuleFileNameA(GetModuleHandle(nullptr), module_path_array, 4096);
+
+			std::string module_path = module_path_array;
+			std::string module_path_new = module_path + ".new";
+			std::string module_path_bak = module_path + ".bak";
+
+			if (GetFileAttributesA(module_path_new.c_str()) != 0xFFFFFFFF)
+				DeleteFileA(module_path_new.c_str());
+
+			if (GetFileAttributesA(module_path_bak.c_str()) != 0xFFFFFFFF)
+				DeleteFileA(module_path_bak.c_str());
+
+			BOOL result_CopyFileA = CopyFileA(module_path.c_str(), module_path_new.c_str(), false);
+
+			FILE* file;
+			LAA_ErrorNum = fopen_s(&file, module_path_new.c_str(), "rb+");
+			if (LAA_ErrorNum == 0)
+			{
+				IMAGE_DOS_HEADER dos_header;
+				size_t result_dos_header = fread(&dos_header, sizeof(IMAGE_DOS_HEADER), 1, file);
+				if (result_dos_header != 1)
+				{
+					fclose(file);
+					LAA_ErrorNum = 1;
+				}
+				else
+				{
+					fseek(file, dos_header.e_lfanew, SEEK_SET);
+
+					IMAGE_NT_HEADERS nt_headers;
+					size_t result_nt_headers = fread(&nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
+					if (result_nt_headers != 1)
+					{
+						fclose(file);
+						LAA_ErrorNum = 2;
+					}
+					else
+					{
+						nt_headers.FileHeader.Characteristics |= IMAGE_FILE_LARGE_ADDRESS_AWARE;
+
+						fseek(file, dos_header.e_lfanew, SEEK_SET);
+						auto wrote = fwrite(&nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
+						fclose(file);
+						if (wrote != 1)
+						{
+							LAA_ErrorNum = 3;
+						}
+						else
+						{
+							BOOL result_moveFile1 = MoveFileA(module_path.c_str(), module_path_bak.c_str());
+							BOOL result_moveFile2 = MoveFileA(module_path_new.c_str(), module_path.c_str());
+							if (!result_moveFile1)
+								LAA_ErrorNum = 4;
+							else if (!result_moveFile2)
+								LAA_ErrorNum = 5;
+
+							if (result_moveFile1 && !result_moveFile2)
+							{
+								// Users original EXE was moved, but we couldn't move replacement for it for some reason
+								// Try restoring the users original EXE so they aren't left with a broken install...
+								MoveFileA(module_path_bak.c_str(), module_path.c_str());
+							}
+						}
+					}
+				}
+			}
+			LAA_State = LAADialogState::Finished;
+		}
+
+		ImGui::SameLine();
+
+		if (ImGui::Button("No", ImVec2(104, 35)))
+		{
+			LAA_State = LAADialogState::NotShowing;
+		}
+
+		ImGui::End();
+	}
+	else if (LAA_State == LAADialogState::Finished)
+	{
+		// Prompted the user & finished performing patches, report the results back to them
+		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSizeConstraints(ImVec2(400, 175), ImVec2(400, 175));
+		if (LAA_ErrorNum == 0)
+		{
+			ImGui::Begin("Game 4GB patched successfully!");
+			ImGui::TextWrapped("re4_tweaks has successfully patched your game EXE (a backup has also been made)\n\nPlease relaunch the game for the patch to take effect!");
+		}
+		else
+		{
+			ImGui::Begin("Game 4GB patch failed...");
+			ImGui::TextWrapped("re4_tweaks failed to patch the game EXE (error %d)\n\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should help find it!", LAA_ErrorNum);
+		}
+
+		ImGui::Dummy(ImVec2(0.0f, 15.0f));
+
+		ImGui::SetCursorPosX(ImGui::GetWindowWidth() - 113);
+
+		if (ImGui::Button("OK", ImVec2(104, 35)))
+		{
+			LAA_State = LAADialogState::NotShowing;
+		}
+
+		ImGui::End();
+	}
+}

--- a/dllmain/LAApatch.h
+++ b/dllmain/LAApatch.h
@@ -1,0 +1,17 @@
+#pragma once
+
+enum class LAADialogState
+{
+	NotShowing,
+	Showing,
+	Finished // show dialog telling user that LAA patch is complete, etc
+};
+
+struct LAApatch
+{
+	void LAARender();
+	bool GameIsLargeAddressAware();
+	LAADialogState LAA_State;
+};
+
+extern LAApatch laa;

--- a/dllmain/WndProcHook.cpp
+++ b/dllmain/WndProcHook.cpp
@@ -6,6 +6,7 @@
 #include "Settings.h"
 #include "ConsoleWnd.h"
 #include "../external/imgui/imgui.h"
+#include "LAApatch.h"
 
 WNDPROC oWndProc;
 HWND hWindow;
@@ -145,7 +146,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		}
 	}
 
-	if (bCfgMenuOpen) {
+	if (bCfgMenuOpen || (laa.LAA_State != LAADialogState::NotShowing)) {
 		// Use raw mouse input because this game is weird and won't let me use window messages properly.
 		RAWINPUTDEVICE rid[1];
 

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -18,6 +18,137 @@ uintptr_t* ptrD3D9Device;
 
 bool NeedsToRestart;
 
+enum class LAADialogState
+{
+	NotShowing,
+	Showing,
+	Finished // show dialog telling user that LAA patch is complete, etc
+};
+
+LAADialogState LAA_State = LAADialogState::NotShowing;
+int LAA_ErrorNum = 0;
+void LAARender()
+{
+	if (GameIsLargeAddressAware())
+	{
+		// Not sure how we ended up here, exit out
+		LAA_State = LAADialogState::NotShowing;
+		return;
+	}
+
+	ImGuiIO& io = ImGui::GetIO();
+
+	if (LAA_State == LAADialogState::Showing)
+	{
+		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
+		ImGui::Begin("4GB / Large Address Aware patch missing!");
+		ImGui::TextWrapped("Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory. Do you want re4_tweaks to patch the game EXE for you? (requires relaunch!)");
+		if (ImGui::Button("Yes"))
+		{
+			char module_path_array[4096];
+			GetModuleFileNameA(GetModuleHandle(nullptr), module_path_array, 4096);
+
+			std::string module_path = module_path_array;
+			std::string module_path_new = module_path + ".new";
+			std::string module_path_bak = module_path + ".bak";
+
+			if (GetFileAttributesA(module_path_new.c_str()) != 0xFFFFFFFF)
+				DeleteFileA(module_path_new.c_str());
+
+			if (GetFileAttributesA(module_path_bak.c_str()) != 0xFFFFFFFF)
+				DeleteFileA(module_path_bak.c_str());
+
+			BOOL result_CopyFileA = CopyFileA(module_path.c_str(), module_path_new.c_str(), false);
+
+			FILE* file;
+			LAA_ErrorNum = fopen_s(&file, module_path_new.c_str(), "rb+");
+			if (LAA_ErrorNum == 0)
+			{
+				IMAGE_DOS_HEADER dos_header;
+				size_t result_dos_header = fread(&dos_header, sizeof(IMAGE_DOS_HEADER), 1, file);
+				if (result_dos_header != 1)
+				{
+					fclose(file);
+					LAA_ErrorNum = 1;
+				}
+				else
+				{
+					fseek(file, dos_header.e_lfanew, SEEK_SET);
+
+					IMAGE_NT_HEADERS nt_headers;
+					size_t result_nt_headers = fread(&nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
+					if (result_nt_headers != 1)
+					{
+						fclose(file);
+						LAA_ErrorNum = 2;
+					}
+					else
+					{
+						nt_headers.FileHeader.Characteristics |= IMAGE_FILE_LARGE_ADDRESS_AWARE;
+
+						fseek(file, dos_header.e_lfanew, SEEK_SET);
+						auto wrote = fwrite(&nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
+						fclose(file);
+						if (wrote != 1)
+						{
+							LAA_ErrorNum = 3;
+						}
+						else
+						{
+							BOOL result_moveFile1 = MoveFileA(module_path.c_str(), module_path_bak.c_str());
+							BOOL result_moveFile2 = MoveFileA(module_path_new.c_str(), module_path.c_str());
+							if (!result_moveFile1)
+								LAA_ErrorNum = 4;
+							else if (!result_moveFile2)
+								LAA_ErrorNum = 5;
+
+							if (result_moveFile1 && !result_moveFile2)
+							{
+								// Users original EXE was moved, but we couldn't move replacement for it for some reason
+								// Try restoring the users original EXE so they aren't left with a broken install...
+								MoveFileA(module_path_bak.c_str(), module_path.c_str());
+							}
+						}
+					}
+				}
+			}
+
+			LAA_State = LAADialogState::Finished;
+		}
+		if (ImGui::Button("No"))
+		{
+			LAA_State = LAADialogState::NotShowing;
+			bCfgMenuOpen = false;
+		}
+		ImGui::End();
+	}
+	else if (LAA_State == LAADialogState::Finished)
+	{
+		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
+		// Prompted the user & finished performing patches, report the results back to them
+		if (LAA_ErrorNum == 0)
+		{
+			ImGui::Begin("Game LAA patched successfully!");
+			ImGui::TextWrapped("re4_tweaks has successfully patched your game EXE (a backup has also been made)\nPlease relaunch the game for the patch to take effect!");
+		}
+		else
+		{
+			ImGui::Begin("Game LAA patch failed...");
+			ImGui::TextWrapped("re4_tweaks failed to patch the game EXE (error %d)\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should find it for you pretty quickly!", LAA_ErrorNum);
+		}
+
+		if (ImGui::Button("Ok"))
+		{
+			LAA_State = LAADialogState::NotShowing;
+			bCfgMenuOpen = false;
+		}
+
+		ImGui::End();
+	}
+}
+
 int Tab = 1;
 void MenuRender()
 {
@@ -586,6 +717,12 @@ HRESULT APIENTRY EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 
 		ImGui_ImplWin32_Init(hWindow);
 		ImGui_ImplDX9_Init(pDevice);
+
+		if (!GameIsLargeAddressAware())
+		{
+			LAA_State = LAADialogState::Showing;
+			bCfgMenuOpen = true; // open menu so we can alert user on startup...
+		}
 	}
 
 	ImGui_ImplDX9_NewFrame();
@@ -603,7 +740,10 @@ HRESULT APIENTRY EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 		ImGui::GetIO().MouseDrawCursor = true;
 
 		//ImGui::ShowDemoWindow();
-		MenuRender();
+		if (LAA_State != LAADialogState::NotShowing)
+			LAARender();
+		else
+			MenuRender();
 	}
 	else
 		ImGui::GetIO().MouseDrawCursor = false;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -31,7 +31,7 @@ void LAARender()
 {
 	if (GameIsLargeAddressAware())
 	{
-		// Not sure how we ended up here, exit out
+		// Exit out in case we needlessly ended up here somehow
 		LAA_State = LAADialogState::NotShowing;
 		return;
 	}
@@ -43,7 +43,8 @@ void LAARender()
 		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
 		ImGui::Begin("4GB / Large Address Aware patch missing!");
-		ImGui::TextWrapped("Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory. Do you want re4_tweaks to patch the game EXE for you? (requires relaunch!)");
+		ImGui::TextWrapped("Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory.\n\nDo you want re4_tweaks to patch the game EXE for you? (requires relaunch!)");
+		
 		if (ImGui::Button("Yes"))
 		{
 			char module_path_array[4096];
@@ -116,6 +117,7 @@ void LAARender()
 
 			LAA_State = LAADialogState::Finished;
 		}
+		ImGui::SameLine();
 		if (ImGui::Button("No"))
 		{
 			LAA_State = LAADialogState::NotShowing;
@@ -125,21 +127,21 @@ void LAARender()
 	}
 	else if (LAA_State == LAADialogState::Finished)
 	{
+		// Prompted the user & finished performing patches, report the results back to them
 		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
-		// Prompted the user & finished performing patches, report the results back to them
 		if (LAA_ErrorNum == 0)
 		{
-			ImGui::Begin("Game LAA patched successfully!");
-			ImGui::TextWrapped("re4_tweaks has successfully patched your game EXE (a backup has also been made)\nPlease relaunch the game for the patch to take effect!");
+			ImGui::Begin("Game 4GB patched successfully!");
+			ImGui::TextWrapped("re4_tweaks has successfully patched your game EXE (a backup has also been made)\n\nPlease relaunch the game for the patch to take effect!");
 		}
 		else
 		{
-			ImGui::Begin("Game LAA patch failed...");
-			ImGui::TextWrapped("re4_tweaks failed to patch the game EXE (error %d)\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should find it for you pretty quickly!", LAA_ErrorNum);
+			ImGui::Begin("Game 4GB patch failed...");
+			ImGui::TextWrapped("re4_tweaks failed to patch the game EXE (error %d)\n\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should help find it!", LAA_ErrorNum);
 		}
 
-		if (ImGui::Button("Ok"))
+		if (ImGui::Button("OK"))
 		{
 			LAA_State = LAADialogState::NotShowing;
 			bCfgMenuOpen = false;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -5,6 +5,7 @@
 #include "dllmain.h"
 #include "Settings.h"
 #include "ConsoleWnd.h"
+#include "LAApatch.h"
 #include "tool_menu.h"
 #include "..\external\imgui\imgui.h"
 #include "..\external\imgui\imgui_impl_win32.h"
@@ -17,139 +18,6 @@ uintptr_t ptrInputProcess;
 uintptr_t* ptrD3D9Device;
 
 bool NeedsToRestart;
-
-enum class LAADialogState
-{
-	NotShowing,
-	Showing,
-	Finished // show dialog telling user that LAA patch is complete, etc
-};
-
-LAADialogState LAA_State = LAADialogState::NotShowing;
-int LAA_ErrorNum = 0;
-void LAARender()
-{
-	if (GameIsLargeAddressAware())
-	{
-		// Exit out in case we needlessly ended up here somehow
-		LAA_State = LAADialogState::NotShowing;
-		return;
-	}
-
-	ImGuiIO& io = ImGui::GetIO();
-
-	if (LAA_State == LAADialogState::Showing)
-	{
-		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
-		ImGui::Begin("4GB / Large Address Aware patch missing!");
-		ImGui::TextWrapped("Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory.\n\nDo you want re4_tweaks to patch the game EXE for you? (requires relaunch!)");
-		
-		if (ImGui::Button("Yes"))
-		{
-			char module_path_array[4096];
-			GetModuleFileNameA(GetModuleHandle(nullptr), module_path_array, 4096);
-
-			std::string module_path = module_path_array;
-			std::string module_path_new = module_path + ".new";
-			std::string module_path_bak = module_path + ".bak";
-
-			if (GetFileAttributesA(module_path_new.c_str()) != 0xFFFFFFFF)
-				DeleteFileA(module_path_new.c_str());
-
-			if (GetFileAttributesA(module_path_bak.c_str()) != 0xFFFFFFFF)
-				DeleteFileA(module_path_bak.c_str());
-
-			BOOL result_CopyFileA = CopyFileA(module_path.c_str(), module_path_new.c_str(), false);
-
-			FILE* file;
-			LAA_ErrorNum = fopen_s(&file, module_path_new.c_str(), "rb+");
-			if (LAA_ErrorNum == 0)
-			{
-				IMAGE_DOS_HEADER dos_header;
-				size_t result_dos_header = fread(&dos_header, sizeof(IMAGE_DOS_HEADER), 1, file);
-				if (result_dos_header != 1)
-				{
-					fclose(file);
-					LAA_ErrorNum = 1;
-				}
-				else
-				{
-					fseek(file, dos_header.e_lfanew, SEEK_SET);
-
-					IMAGE_NT_HEADERS nt_headers;
-					size_t result_nt_headers = fread(&nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
-					if (result_nt_headers != 1)
-					{
-						fclose(file);
-						LAA_ErrorNum = 2;
-					}
-					else
-					{
-						nt_headers.FileHeader.Characteristics |= IMAGE_FILE_LARGE_ADDRESS_AWARE;
-
-						fseek(file, dos_header.e_lfanew, SEEK_SET);
-						auto wrote = fwrite(&nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
-						fclose(file);
-						if (wrote != 1)
-						{
-							LAA_ErrorNum = 3;
-						}
-						else
-						{
-							BOOL result_moveFile1 = MoveFileA(module_path.c_str(), module_path_bak.c_str());
-							BOOL result_moveFile2 = MoveFileA(module_path_new.c_str(), module_path.c_str());
-							if (!result_moveFile1)
-								LAA_ErrorNum = 4;
-							else if (!result_moveFile2)
-								LAA_ErrorNum = 5;
-
-							if (result_moveFile1 && !result_moveFile2)
-							{
-								// Users original EXE was moved, but we couldn't move replacement for it for some reason
-								// Try restoring the users original EXE so they aren't left with a broken install...
-								MoveFileA(module_path_bak.c_str(), module_path.c_str());
-							}
-						}
-					}
-				}
-			}
-
-			LAA_State = LAADialogState::Finished;
-		}
-		ImGui::SameLine();
-		if (ImGui::Button("No"))
-		{
-			LAA_State = LAADialogState::NotShowing;
-			bCfgMenuOpen = false;
-		}
-		ImGui::End();
-	}
-	else if (LAA_State == LAADialogState::Finished)
-	{
-		// Prompted the user & finished performing patches, report the results back to them
-		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
-		if (LAA_ErrorNum == 0)
-		{
-			ImGui::Begin("Game 4GB patched successfully!");
-			ImGui::TextWrapped("re4_tweaks has successfully patched your game EXE (a backup has also been made)\n\nPlease relaunch the game for the patch to take effect!");
-		}
-		else
-		{
-			ImGui::Begin("Game 4GB patch failed...");
-			ImGui::TextWrapped("re4_tweaks failed to patch the game EXE (error %d)\n\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should help find it!", LAA_ErrorNum);
-		}
-
-		if (ImGui::Button("OK"))
-		{
-			LAA_State = LAADialogState::NotShowing;
-			bCfgMenuOpen = false;
-		}
-
-		ImGui::End();
-	}
-}
 
 int Tab = 1;
 void MenuRender()
@@ -720,10 +588,9 @@ HRESULT APIENTRY EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 		ImGui_ImplWin32_Init(hWindow);
 		ImGui_ImplDX9_Init(pDevice);
 
-		if (!GameIsLargeAddressAware())
+		if (!laa.GameIsLargeAddressAware())
 		{
-			LAA_State = LAADialogState::Showing;
-			bCfgMenuOpen = true; // open menu so we can alert user on startup...
+			laa.LAA_State = LAADialogState::Showing;
 		}
 	}
 
@@ -735,6 +602,15 @@ HRESULT APIENTRY EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 	con.ShowConsoleOutput();
 	#endif 
 
+	// Calls the LAA window if needed
+	if (laa.LAA_State != LAADialogState::NotShowing)
+	{
+		// Make cursor visible
+		ImGui::GetIO().MouseDrawCursor = true;
+
+		laa.LAARender();
+	}
+
 	// Calls the actual menu function
 	if (bCfgMenuOpen)
 	{
@@ -742,12 +618,10 @@ HRESULT APIENTRY EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 		ImGui::GetIO().MouseDrawCursor = true;
 
 		//ImGui::ShowDemoWindow();
-		if (LAA_State != LAADialogState::NotShowing)
-			LAARender();
-		else
-			MenuRender();
+		MenuRender();
 	}
-	else
+	
+	if (!bCfgMenuOpen && (laa.LAA_State == LAADialogState::NotShowing))
 		ImGui::GetIO().MouseDrawCursor = false;
 
 	ImGui::EndFrame();

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -73,6 +73,16 @@ void __declspec(naked) Esp04TransHook()
 		_asm {ret}
 }
 
+bool GameIsLargeAddressAware() // TODO: move to a utility.cpp file?
+{
+	static PBYTE module_base = reinterpret_cast<PBYTE>(GetModuleHandle(nullptr));
+
+	PIMAGE_DOS_HEADER dos_header = reinterpret_cast<PIMAGE_DOS_HEADER>(module_base);
+	PIMAGE_NT_HEADERS nt_headers = reinterpret_cast<PIMAGE_NT_HEADERS>(module_base + dos_header->e_lfanew);
+
+	return (nt_headers->FileHeader.Characteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) == IMAGE_FILE_LARGE_ADDRESS_AWARE;
+}
+
 void HandleAppID()
 {
 	//Create missing steam_appid file

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -73,16 +73,6 @@ void __declspec(naked) Esp04TransHook()
 		_asm {ret}
 }
 
-bool GameIsLargeAddressAware() // TODO: move to a utility.cpp file?
-{
-	static PBYTE module_base = reinterpret_cast<PBYTE>(GetModuleHandle(nullptr));
-
-	PIMAGE_DOS_HEADER dos_header = reinterpret_cast<PIMAGE_DOS_HEADER>(module_base);
-	PIMAGE_NT_HEADERS nt_headers = reinterpret_cast<PIMAGE_NT_HEADERS>(module_base + dos_header->e_lfanew);
-
-	return (nt_headers->FileHeader.Characteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) == IMAGE_FILE_LARGE_ADDRESS_AWARE;
-}
-
 void HandleAppID()
 {
 	//Create missing steam_appid file

--- a/dllmain/dllmain.h
+++ b/dllmain/dllmain.h
@@ -10,3 +10,5 @@ extern bool bisDebugBuild;
 
 extern std::string iniPath;
 extern std::string game_version;
+
+bool GameIsLargeAddressAware();

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="ConsoleWnd.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="KeyboardMouseTweaks.cpp" />
+    <ClCompile Include="LAApatch.cpp" />
     <ClCompile Include="MouseTurning.cpp" />
     <ClCompile Include="qtefixes.cpp" />
     <ClCompile Include="roomInfo.cpp" />
@@ -170,6 +171,7 @@
     <ClInclude Include="cfgMenu.h" />
     <ClInclude Include="HandleLimits.h" />
     <ClInclude Include="KeyboardMouseTweaks.h" />
+    <ClInclude Include="LAApatch.h" />
     <ClInclude Include="MouseTurning.h" />
     <ClInclude Include="qtefixes.h" />
     <ClInclude Include="Settings.h" />

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="MouseTurning.cpp">
       <Filter>dllmain</Filter>
     </ClCompile>
+    <ClCompile Include="LAApatch.cpp">
+      <Filter>dllmain</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\includes\stdafx.h">
@@ -284,6 +287,9 @@
     </ClInclude>
     <ClInclude Include="..\includes\hashes.h">
       <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="LAApatch.h">
+      <Filter>dllmain</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
As mentioned at #35 

I changed the dialog titles to use 4GB patch instead of LAA patch since people are probably more familar with the 4GB name, added some extra line-breaks in, & also added the `ImGui::SameLine()` fix to the button positions.

![22-01-16_21-15-43_bio4](https://user-images.githubusercontent.com/1755499/149678355-84f83aad-0879-4842-9410-b45af3cb7cc0.jpg)
![22-01-16_21-15-49_bio4](https://user-images.githubusercontent.com/1755499/149678357-ea5764cd-46f9-4327-9518-ab24e82b872f.jpg)

Also did a quick test of removing my user permissions from the bio4.exe first before patching - interesting thing is that when I tried running game afterwards, the patch still worked fine! Looks like something added all the permissions back to the EXE after I ran it...

Guessing that's Steam related since game was in SteamApps folder, if I tried with a copy of the game in another folder then removing permissions gave a more expected result (excuse weird font in this pic, for some reason when I run 1.0.6 it scales the window weirdly for some reason)

![22-01-16_21-07-20_bio4](https://user-images.githubusercontent.com/1755499/149678435-8b3bc4d4-483e-40fe-94f7-792106c8ab3c.jpg)

(I was hoping to move buttons to right side too so they'd look closer to actual Win32 msgboxes, but couldn't find a way to anchor them cleanly, only way I saw was to specify X position directly, which wouldn't be good if dialog ever needs resizing...)