### PR TITLE
Wrappers: add `xinput1_3` & `x3daudio1_7` wrappers

### DIFF
--- a/Wrappers/wrapper.def
+++ b/Wrappers/wrapper.def
@@ -3,21 +3,18 @@ EXPORTS
 
 
 ; ****
-;LIBRARY "dsound"    <--- Needs to have the correct ordinals since some programs use the ordinal numbers for dsound APIs
+;LIBRARY "xinput1_3"    <--- Needs correct ordinals, some games don't include import names for this some reason
 ; ****
-DirectSoundCreate				@1
-DirectSoundEnumerateA			@2
-DirectSoundEnumerateW			@3
+DllMain				@1
+XInputGetState			@2
+XInputSetState			@3
+XInputGetCapabilities	@4
+XInputEnable			@5
+XInputGetDSoundAudioDeviceGuids		@6
+XInputGetBatteryInformation	@7
+XInputGetKeystroke	@8
 DllCanUnloadNow					PRIVATE
 DllGetClassObject				PRIVATE
-DirectSoundCaptureCreate		@6
-DirectSoundCaptureEnumerateA	@7
-DirectSoundCaptureEnumerateW	@8
-GetDeviceID						@9
-DirectSoundFullDuplexCreate		@10
-DirectSoundCreate8				@11
-DirectSoundCaptureCreate8		@12
-
 
 ; ****
 ;Forces Nvidia and AMD high performance graphics
@@ -1302,3 +1299,10 @@ NSPStartup
 TransmitFile
 AcceptEx
 GetAcceptExSockaddrs
+
+; ****
+;LIBRARY "x3daudio1_7"
+; ****
+X3DAudioInitialize
+X3DAudioCalculate
+CreateFX

--- a/Wrappers/wrapper.h
+++ b/Wrappers/wrapper.h
@@ -33,7 +33,9 @@ namespace Wrapper
 	visit(version) \
 	visit(wininet) \
 	visit(winmm) \
-	visit(wsock32)
+	visit(wsock32) \
+	visit(x3daudio1_7) \
+	visit(xinput1_3)
 
 // Wrappers
 #include "bcrypt.h"
@@ -57,6 +59,8 @@ namespace Wrapper
 #include "wininet.h"
 #include "winmm.h"
 #include "wsock32.h"
+#include "x3daudio1_7.h"
+#include "xinput1_3.h"
 
 #define DECLARE_PROC_VARABLES(procName, unused) \
 	extern FARPROC procName ## _funct; \

--- a/Wrappers/x3daudio1_7.h
+++ b/Wrappers/x3daudio1_7.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define VISIT_PROCS_X3DAUDIO1_7(visit) \
+	visit(X3DAudioInitialize, jmpaddr) \
+	visit(X3DAudioCalculate, jmpaddr) \
+	visit(CreateFX, jmpaddr)
+
+#ifdef PROC_CLASS
+PROC_CLASS(x3daudio1_7, dll, VISIT_PROCS_X3DAUDIO1_7, VISIT_PROCS_BLANK)
+#endif

--- a/Wrappers/xinput1_3.h
+++ b/Wrappers/xinput1_3.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#define VISIT_PROCS_XINPUT1_3(visit) \
+	visit(XInputGetState, jmpaddr) \
+	visit(XInputSetState, jmpaddr) \
+	visit(XInputGetCapabilities, jmpaddr) \
+	visit(XInputEnable, jmpaddr) \
+	visit(XInputGetDSoundAudioDeviceGuids, jmpaddr) \
+	visit(XInputGetBatteryInformation, jmpaddr) \
+	visit(XInputGetKeystroke, jmpaddr)
+
+#ifdef PROC_CLASS
+PROC_CLASS(xinput1_3, dll, VISIT_PROCS_XINPUT1_3, VISIT_PROCS_BLANK)
+#endif

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -219,6 +219,7 @@ void Settings::ReadSettings()
 	cfg.iWindowPositionX = iniReader.ReadInteger("DISPLAY", "WindowPositionX", -1);
 	cfg.iWindowPositionY = iniReader.ReadInteger("DISPLAY", "WindowPositionY", -1);
 	cfg.bRememberWindowPos = iniReader.ReadBoolean("DISPLAY", "RememberWindowPos", false);
+	cfg.sWrappedDllPath = iniReader.ReadString("MISC", "WrappedDLLPath", "");
 	cfg.b60fpsFixes = iniReader.ReadBoolean("MISC", "60fpsFixes", true);
 	cfg.bFixQTE = iniReader.ReadBoolean("MISC", "FixQTE", true);
 	cfg.bAshleyJPCameraAngles = iniReader.ReadBoolean("MISC", "AshleyJPCameraAngles", false);
@@ -272,7 +273,6 @@ void Settings::WriteSettings()
 		iniFile << defaultSettings;
 		iniFile.close();
 	}
-
 	iniReader.WriteFloat("DISPLAY", "FOVAdditional", cfg.fFOVAdditional);
 	iniReader.WriteBoolean("DISPLAY", "FixUltraWideAspectRatio", cfg.bFixUltraWideAspectRatio);
 	iniReader.WriteBoolean("DISPLAY", "FixVsyncToggle", cfg.bFixVsyncToggle);
@@ -288,6 +288,7 @@ void Settings::WriteSettings()
 	iniReader.WriteInteger("DISPLAY", "WindowPositionX", cfg.iWindowPositionX);
 	iniReader.WriteInteger("DISPLAY", "WindowPositionY", cfg.iWindowPositionY);
 	iniReader.WriteBoolean("DISPLAY", "RememberWindowPos", cfg.bRememberWindowPos);
+	iniReader.WriteString("MISC", "WrappedDLLPath", cfg.sWrappedDllPath);
 	iniReader.WriteBoolean("MISC", "FixQTE", cfg.bFixQTE);
 	iniReader.WriteBoolean("MISC", "AshleyJPCameraAngles", cfg.bAshleyJPCameraAngles);
 	iniReader.WriteBoolean("MISC", "SkipIntroLogos", cfg.bSkipIntroLogos);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -29,6 +29,7 @@ struct Settings
 	int iWindowPositionY;
 	bool bRememberWindowPos;
 	bool b60fpsFixes;
+	std::string sWrappedDllPath;
 	bool bFixQTE;
 	bool bSkipIntroLogos;
 	bool bEnableDebugMenu;

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -17,7 +17,6 @@
 #include "KeyboardMouseTweaks.h"
 #include "ExceptionHandler.h"
 
-std::string RealDllPath;
 std::string WrapperMode;
 std::string WrapperName;
 std::string rootPath;
@@ -423,7 +422,16 @@ void LoadRealDLL(HMODULE hModule)
 	// Get wrapper mode
 	const char* RealWrapperMode = Wrapper::GetWrapperName((WrapperMode.size()) ? WrapperMode.c_str() : WrapperName.c_str());
 
-	proxy_dll = Wrapper::CreateWrapper((RealDllPath.size()) ? RealDllPath.c_str() : nullptr, (WrapperMode.size()) ? WrapperMode.c_str() : nullptr, WrapperName.c_str());
+	const char* wrappedDllPath = nullptr;
+	if (cfg.sWrappedDllPath.size())
+	{
+		wrappedDllPath = cfg.sWrappedDllPath.c_str();
+		// User has specified a DLL to wrap, make sure it exists first:
+		if (GetFileAttributesA(wrappedDllPath) == 0xFFFFFFFF)
+			wrappedDllPath = nullptr;
+	}
+	
+	proxy_dll = Wrapper::CreateWrapper(wrappedDllPath, (WrapperMode.size()) ? WrapperMode.c_str() : nullptr, WrapperName.c_str());
 }
 
 // Dll main function
@@ -435,13 +443,13 @@ bool APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpReserved)
 	{
 	case DLL_PROCESS_ATTACH:
 
-		LoadRealDLL(hModule);
-
 		#ifdef VERBOSE
 		con.AddLogChar("\n");
 		#endif
 
 		Init_Main();
+
+		LoadRealDLL(hModule);
 
 		break;
 	case DLL_PROCESS_DETACH:

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -165,6 +165,8 @@
     <ClInclude Include="..\Wrappers\winmm.h" />
     <ClInclude Include="..\Wrappers\wrapper.h" />
     <ClInclude Include="..\Wrappers\wsock32.h" />
+    <ClInclude Include="..\Wrappers\x3daudio1_7.h" />
+    <ClInclude Include="..\Wrappers\xinput1_3.h" />
     <ClInclude Include="60fpsFixes.h" />
     <ClInclude Include="ConsoleWnd.h" />
     <ClInclude Include="ExceptionHandler.h" />

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -300,6 +300,12 @@
     <ClInclude Include="ExceptionHandler.h">
       <Filter>dllmain</Filter>
     </ClInclude>
+    <ClInclude Include="..\Wrappers\xinput1_3.h">
+      <Filter>Wrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Wrappers\x3daudio1_7.h">
+      <Filter>Wrappers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="includes">

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -52,6 +52,10 @@ WindowPositionY = -1
 RememberWindowPos = false
 
 [MISC]
+; Path to DLL to wrap, comment or leave empty to wrap system DLL
+; (only set this if you need re4_tweaks to 'chain-load' another DLL that makes use of the same filename)
+;WrappedDLLPath = 
+
 ; Fixes animation inconsistencies between 30 and 60 FPS that were not addressed by the developers.
 60fpsFixes = true
 


### PR DESCRIPTION
Both seem to be working with 1.1.0 at least, had to replace the `dsound` ordinals in Wrapper.def since xinput1_3 also requires fixed ordinals in some cases, game doesn't use dsound anyway afaik.

Using xinput1_3 might cause some issues with controllers for some people though, never had issues with it myself, but had some reports about that before (maybe they were using controller mapping software or something like that), x3daudio1_7 should be safer though since there's not much that mess with game audio AFAIK.

E: oh there is https://github.com/kosumosu/x3daudio1_7_hrtf that would conflict with x3daudio1_7 though... unfortunately that also works via the X3DAudio exports like `X3DAudioInitialize` etc, so chainloading with LoadLibrary probably wouldn't help there.

Not sure how much work it'd be to add in, but might be nice if maybe the wrapped DLL could be specified in INI instead of always using system DLL, so that we could load eg. x3daudio1_7_hrtf.dll and pass exports over to it - some mod DLLs use their DLL filename to find the system DLL though, so could cause issues with some things...

E2: hm, looks like we have a `RealDllPath` in dllmain.cpp that might allow for something like this, but nothing sets it up atm - seems INI is only read from after we've loaded the DLL though, so would probably need to reorder some things to allow customizing that...