### PR TITLE
FallbackToEnglishKeyIcons: falls back to English key icons for unsupported languages

### DIFF
--- a/dllmain/KeyboardMouseTweaks.cpp
+++ b/dllmain/KeyboardMouseTweaks.cpp
@@ -39,6 +39,21 @@ LastDevice GetLastUsedDevice()
 
 HKL __stdcall GetKeyboardLayout_Hook(DWORD idThread)
 {
+	auto userLanguage = GetKeyboardLayout(idThread);
+
+	// Return user language if it's one that the game should have support for
+	switch (PRIMARYLANGID(userLanguage))
+	{
+	case LANG_CHINESE:
+	case LANG_ENGLISH:
+	case LANG_FRENCH:
+	case LANG_GERMAN:
+	case LANG_ITALIAN:
+	case LANG_JAPANESE:
+	case LANG_SPANISH:
+		return userLanguage;
+	}
+
 	return (HKL)MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
 }
 
@@ -156,7 +171,7 @@ void Init_KeyboardMouseTweaks()
 		injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(0), 2, true);
 	}
 
-	if (cfg.bForceEnglishKeyIcons)
+	if (cfg.bFallbackToEnglishKeyIcons)
 	{
 		// Replace GetKeyboardLayout IAT to point to our GetKeyboardLayout_Hook
 		pattern = hook::pattern("68 FF 00 00 00 8D 85 ? ? ? ? 6A 00 50 C6 85 ? ? ? ? 00 E8 ? ? ? ? 8B 3D ? ? ? ?");

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -236,7 +236,7 @@ void Settings::ReadSettings()
 	cfg.bFixSniperZoom = iniReader.ReadBoolean("MOUSE", "FixSniperZoom", true);
 	cfg.bFixSniperFocus = iniReader.ReadBoolean("MOUSE", "FixSniperFocus", true);
 	cfg.bFixRetryLoadMouseSelector = iniReader.ReadBoolean("MOUSE", "FixRetryLoadMouseSelector", true);
-	cfg.bForceEnglishKeyIcons = iniReader.ReadBoolean("KEYBOARD", "ForceEnglishKeyIcons", false);
+	cfg.bFallbackToEnglishKeyIcons = iniReader.ReadBoolean("KEYBOARD", "FallbackToEnglishKeyIcons", true);
 	cfg.flip_item_up = iniReader.ReadString("KEYBOARD", "flip_item_up", "HOME");
 	cfg.flip_item_down = iniReader.ReadString("KEYBOARD", "flip_item_down", "END");
 	cfg.flip_item_left = iniReader.ReadString("KEYBOARD", "flip_item_left", "INSERT");
@@ -323,7 +323,7 @@ void Settings::WriteSettings()
 	iniReader.WriteBoolean("MOUSE", "FixSniperZoom", cfg.bFixSniperZoom);
 	iniReader.WriteBoolean("MOUSE", "FixSniperFocus", cfg.bFixSniperFocus);
 	iniReader.WriteBoolean("MOUSE", "FixRetryLoadMouseSelector", cfg.bFixRetryLoadMouseSelector);
-	iniReader.WriteBoolean("KEYBOARD", "ForceEnglishKeyIcons", cfg.bForceEnglishKeyIcons);
+	iniReader.WriteBoolean("KEYBOARD", "FallbackToEnglishKeyIcons", cfg.bFallbackToEnglishKeyIcons);
 	iniReader.WriteString("KEYBOARD", "flip_item_up", " " + cfg.flip_item_up);
 	iniReader.WriteString("KEYBOARD", "flip_item_down", " " + cfg.flip_item_down);
 	iniReader.WriteString("KEYBOARD", "flip_item_left", " " + cfg.flip_item_left);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -236,6 +236,7 @@ void Settings::ReadSettings()
 	cfg.bFixSniperZoom = iniReader.ReadBoolean("MOUSE", "FixSniperZoom", true);
 	cfg.bFixSniperFocus = iniReader.ReadBoolean("MOUSE", "FixSniperFocus", true);
 	cfg.bFixRetryLoadMouseSelector = iniReader.ReadBoolean("MOUSE", "FixRetryLoadMouseSelector", true);
+	cfg.bForceEnglishKeyIcons = iniReader.ReadBoolean("KEYBOARD", "ForceEnglishKeyIcons", false);
 	cfg.flip_item_up = iniReader.ReadString("KEYBOARD", "flip_item_up", "HOME");
 	cfg.flip_item_down = iniReader.ReadString("KEYBOARD", "flip_item_down", "END");
 	cfg.flip_item_left = iniReader.ReadString("KEYBOARD", "flip_item_left", "INSERT");
@@ -322,6 +323,7 @@ void Settings::WriteSettings()
 	iniReader.WriteBoolean("MOUSE", "FixSniperZoom", cfg.bFixSniperZoom);
 	iniReader.WriteBoolean("MOUSE", "FixSniperFocus", cfg.bFixSniperFocus);
 	iniReader.WriteBoolean("MOUSE", "FixRetryLoadMouseSelector", cfg.bFixRetryLoadMouseSelector);
+	iniReader.WriteBoolean("KEYBOARD", "ForceEnglishKeyIcons", cfg.bForceEnglishKeyIcons);
 	iniReader.WriteString("KEYBOARD", "flip_item_up", " " + cfg.flip_item_up);
 	iniReader.WriteString("KEYBOARD", "flip_item_down", " " + cfg.flip_item_down);
 	iniReader.WriteString("KEYBOARD", "flip_item_left", " " + cfg.flip_item_left);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -36,7 +36,7 @@ struct Settings
 	bool bEnableControllerSens;
 	bool bUseMouseTurning;
 	float fTurnSensitivity;
-	bool bForceEnglishKeyIcons;
+	bool bFallbackToEnglishKeyIcons;
 	bool bFixSniperZoom;
 	bool bFixSniperFocus;
 	bool bFixRetryLoadMouseSelector;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -36,6 +36,7 @@ struct Settings
 	bool bEnableControllerSens;
 	bool bUseMouseTurning;
 	float fTurnSensitivity;
+	bool bForceEnglishKeyIcons;
 	bool bFixSniperZoom;
 	bool bFixSniperFocus;
 	bool bFixRetryLoadMouseSelector;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -487,8 +487,8 @@ void MenuRender()
 				ImGui::Spacing();
 
 				// English key icons
-				cfg.HasUnsavedChanges |= ImGui::Checkbox("ForceEnglishKeyIcons", &cfg.bForceEnglishKeyIcons);
-				ImGui::TextWrapped("Game seems to only support certain keyboard layouts/languages, if the game fails to show keys for you, try enabling this (requires game restart)");
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("FallbackToEnglishKeyIcons", &cfg.bFallbackToEnglishKeyIcons);
+				ImGui::TextWrapped("Game will turn keys invisible for certain unsupported keyboard languages, enabling this should make game use English keys for unsupported ones instead (requires game restart)");
 			}
 
 			// Frame rate tab

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -481,6 +481,14 @@ void MenuRender()
 				ImGui::InputText("QTE key 2", cfg.QTE_key_2.data(), 64, ImGuiInputTextFlags_CharsUppercase);
 				cfg.HasUnsavedChanges |= ImGui::IsItemEdited();
 				ImGui::PopItemWidth;
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
+				// English key icons
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("ForceEnglishKeyIcons", &cfg.bForceEnglishKeyIcons);
+				ImGui::TextWrapped("Game seems to only support certain keyboard layouts/languages, if the game fails to show keys for you, try enabling this (requires game restart)");
 			}
 
 			// Frame rate tab

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -100,9 +100,10 @@ FixSniperFocus = true
 FixRetryLoadMouseSelector = true
 
 [KEYBOARD]
-; Forces English key icons to appear for action buttons displayed on screen
-; (game seems to only support certain keyboard languages, if the game fails to show keys for you, try enabling this)
-ForceEnglishKeyIcons = false
+; Game will turn keys invisible for certain unsupported keyboard languages
+; Enabling this should make game use English keys for unsupported ones instead
+; (if game supports your current language it should still use it however)
+FallbackToEnglishKeyIcons = true
 
 ; Key bindings for flipping items in the inventory screen when using keyboard and mouse.
 ; Normally, you can only rotate them with the keyboard, not flip them. Flipping was possible in the old PC port and is

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -100,6 +100,10 @@ FixSniperFocus = true
 FixRetryLoadMouseSelector = true
 
 [KEYBOARD]
+; Forces English key icons to appear for action buttons displayed on screen
+; (game seems to only support certain keyboard languages, if the game fails to show keys for you, try enabling this)
+ForceEnglishKeyIcons = false
+
 ; Key bindings for flipping items in the inventory screen when using keyboard and mouse.
 ; Normally, you can only rotate them with the keyboard, not flip them. Flipping was possible in the old PC port and is
 ; possible using a controller.


### PR DESCRIPTION
Seems to work across 1.1.0/1.0.6/1.0.6debug, it might be nice for re4_tweaks to activate this automatically depending on known-bad layouts (or maybe just always activate it, if no other layout besides English shows correctly?)

E: oh I missed the image you posted of all the available keys - I guess that shows that languages besides English must be supported then. Too bad we don't have any list of the ones that work, unless maybe it's all the in-game translations?

E2: updated so that languages that have translation will still be used, and made it enabled by default

Here's a build if anyone is able to test it out:
[re4_tweaks1.7.4-englishKeyFallback.zip](https://github.com/nipkownix/re4_tweaks/files/7991176/re4_tweaks1.7.4-englishKeyFallback.zip)

