### PR TITLE
Remove savegame SteamID checks, allows easier save transfers, fixes #67

### DIFF
--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -138,6 +138,11 @@ void Init_Main()
 
 	Init_ExceptionHandler();
 
+	// Remove savegame SteamID checks, allows easier save transfers
+	pattern = hook::pattern("8B 88 40 1E 00 00 3B 4D ? 0F 85 ? ? ? ?");
+	Nop(pattern.count(1).get(0).get<uint8_t>(0x9), 6);
+	Nop(pattern.count(1).get(0).get<uint8_t>(0x18), 6);
+
 	// Fix aspect ratio when playing in ultra-wide. Only 21:9 was tested.
 	if (cfg.bFixUltraWideAspectRatio)
 		Init_UltraWideFix();


### PR DESCRIPTION
Tested with 1.1.0/1.0.6/1.0.6debug, should allow swapping out savegame00.sav for other peoples fine.

Seems the steamID inside the save is also used as part of the CRC calculation, but that should be unaffected, loading from other persons save & making new save seems to rewrite the SteamID part at 0x1E40 with the users one instead.

Fixes #67