### PR TITLE
FixDisplayMode: use EnumDisplayDevices to get refresh rate of monitor 0

### DIFF
--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -192,23 +192,28 @@ void Init_Main()
 	// Hook func that runs EnumAdapterModes & checks for 60Hz modes, make it use the refresh rate from Windows instead
 	if (cfg.bFixDisplayMode)
 	{
-
 		if (cfg.iCustomRefreshRate > -1)
 		{
 			g_UserRefreshRate = cfg.iCustomRefreshRate;
 		}
 		else
 		{
-			DEVMODE lpDevMode;
-			if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &lpDevMode) == 0)
+			DISPLAY_DEVICE device{ 0 };
+			device.cb = sizeof(DISPLAY_DEVICE);
+			DEVMODE lpDevMode{ 0 };
+			if (EnumDisplayDevices(NULL, 0, &device, 0) == false || 
+				EnumDisplaySettings(device.DeviceName, ENUM_CURRENT_SETTINGS, &lpDevMode) == false)
 			{
-				#ifdef VERBOSE
+#ifdef VERBOSE
 				con.AddLogChar("Couldn't read the display refresh rate. Using fallback value.");
-				#endif
+#endif
 				g_UserRefreshRate = 60; // Fallback value.
 			}
 			else
 			{
+#ifdef VERBOSE
+				con.AddLogChar("Device 0 name: %s", device.DeviceName);
+#endif
 				g_UserRefreshRate = lpDevMode.dmDisplayFrequency;
 			}
 		}


### PR DESCRIPTION
Broke: letting game filter display modes to only 60Hz ones
Woke: using `EnumDisplaySettings` with NULL device name to get desktop refresh rate
Bespoke: using `EnumDisplayDevices` to get device name of adapter 0 first, to use with `EnumDisplaySettings`

This seemed to fix the green screen issue, I guess EnumDisplaySettings with NULL device was fetching from wrong monitor.

Hopefully `EnumDisplayDevices` device indexes will match up with D3D's, so maybe in future we can use the adapter number from games config.ini with it (right now theres a bunch of places where game ignores adapter number though and hardcodes adapter 0, eg. `D3D_FillDisplayModeVector` - might need to hook the D3D calls they're making, or reimplement the whole caller,  shouldn't be too hard to track them down though since they all use g_IDirect3D9 / Direct3DCreate9 afaik)

Fixes #51 