### PR TITLE
MouseTurning: add modifier key-combo to temporarily disable turning

### DIFF
--- a/dllmain/ConsoleWnd.cpp
+++ b/dllmain/ConsoleWnd.cpp
@@ -7,6 +7,7 @@
 #include "..\external\imgui\imgui.h"
 #include "..\external\imgui\imgui_impl_win32.h"
 #include "..\external\imgui\imgui_impl_dx9.h"
+#include "WndProcHook.h"
 
 ConsoleOutput con;
 
@@ -14,40 +15,22 @@ ImGuiTextBuffer     Buf;
 ImVector<int>       LineOffsets; // Index to lines offset. We maintain this with AddLog() calls.
 bool                AutoScroll = true;  // Keep scrolling if already at the bottom.
 
-std::vector<KeyBindingInfo> ConsoleKeyInfoVector;
-
 std::string TitleCombo;
 
-// Reads the key combo into an array containing the key id and isPressed state
+std::vector<uint32_t> ConsoleCombo;
+
 bool ParseConsoleKeyCombo(std::string_view in_combo)
 {
-    ConsoleKeyInfoVector.clear();
-
-	std::vector<uint32_t> ConsoleCombo = ParseKeyCombo(in_combo);
-
-	for (auto& key : ConsoleCombo)
-	{
-		KeyBindingInfo curkey = { key, false };
-        ConsoleKeyInfoVector.push_back(curkey);
-	}
-
-	return ConsoleKeyInfoVector.size() > 0;
+    ConsoleCombo.clear();
+    ConsoleCombo = ParseKeyCombo(in_combo);
+    return ConsoleCombo.size() > 0;
 }
 
-void ConsoleBinding(UINT uMsg, WPARAM wParam)
+void ConsoleBinding()
 {
-    if (IsComboKeyPressed(&ConsoleKeyInfoVector, uMsg, wParam))
+    if (IsComboKeyPressed(&ConsoleCombo))
     {
         bConsoleOpen = !bConsoleOpen;
-    }
-
-    switch (uMsg) {
-    case WM_KEYDOWN:
-        if (wParam == VK_NUMPAD3)
-        {
-            con.AddLogChar("Sono me... dare no me?");
-        }
-        break;
     }
 }
 

--- a/dllmain/ConsoleWnd.cpp
+++ b/dllmain/ConsoleWnd.cpp
@@ -16,6 +16,8 @@ bool                AutoScroll = true;  // Keep scrolling if already at the bott
 
 std::vector<KeyBindingInfo> ConsoleKeyInfoVector;
 
+std::string TitleCombo;
+
 // Reads the key combo into an array containing the key id and isPressed state
 bool ParseConsoleKeyCombo(std::string_view in_combo)
 {
@@ -203,7 +205,7 @@ void ConsoleOutput::ShowConsoleOutput()
     ImGui::SetNextWindowSize(ImVec2(500, 400), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowCollapsed(!bConsoleOpen);
 
-    std::string name = std::string("Console Output - ") + cfg.sConsoleKeyCombo + std::string(" to Show/Hide");
+    std::string name = std::string("Console Output - ") + con.TitleKeyCombo + std::string(" to Show/Hide");
     ImGui::Begin(name.data());
     ImGui::End();
     Draw(name.data());

--- a/dllmain/ConsoleWnd.h
+++ b/dllmain/ConsoleWnd.h
@@ -13,7 +13,7 @@ struct ConsoleOutput
 	void Clear();
 };
 
-void ConsoleBinding(UINT uMsg, WPARAM wParam);
+void ConsoleBinding();
 bool ParseConsoleKeyCombo(std::string_view in_combo);
 
 extern ConsoleOutput con;

--- a/dllmain/ConsoleWnd.h
+++ b/dllmain/ConsoleWnd.h
@@ -2,6 +2,7 @@
 
 struct ConsoleOutput
 {
+	std::string TitleKeyCombo;
 	void ShowConsoleOutput();
 	void AddLogChar(const char* fmt, ...);
 	void AddLogHex(int fmt, ...);

--- a/dllmain/MouseTurning.cpp
+++ b/dllmain/MouseTurning.cpp
@@ -60,7 +60,15 @@ bool MouseTurnEnabled()
 		}
 	}
 
-	bool state = cfg.bUseMouseTurning && !modifierPressed;
+	bool state = cfg.bUseMouseTurning;
+
+	// Invert mouse turning setting if modifier pressed
+	// If mouse turning enabled: modifier disables turning, allows camera movement
+	// If mouse turning disabled: modifier enables mouse turning temporarily
+	// (if user wants to completely disable mouse turning, they can clear the combination)
+	if (modifierPressed)
+		state = !state;
+
 	bMouseTurnStateChanged = bPrevMouseTurnState != state;
 	bPrevMouseTurnState = state;
 

--- a/dllmain/MouseTurning.cpp
+++ b/dllmain/MouseTurning.cpp
@@ -4,6 +4,7 @@
 #include "Settings.h"
 #include "ConsoleWnd.h"
 #include "KeyboardMouseTweaks.h"
+#include "WndProcHook.h"
 
 uintptr_t* ptrCamXmovAddr;
 uintptr_t* ptrKnife_r3_downMovAddr;
@@ -19,9 +20,8 @@ static uint32_t* ptrMovInputState;
 static uint32_t* ptrMouseAimMode;
 
 uint32_t* ptrCharRotationBase;
+uint32_t* ptrCamXPosAddr;
 
-bool shouldMouseTurn;
-bool modifierPressed;
 bool isTurn;
 
 DWORD _EAX;
@@ -39,29 +39,21 @@ int intMovInputState()
     return *(int8_t*)(ptrMovInputState);
 }
 
-std::vector<KeyBindingInfo> TurnModifierKeyInfoVector;
+std::vector<uint32_t> mouseTurnModifierCombo;
 
 bool ParseMouseTurnModifierCombo(std::string_view in_combo)
 {
-	TurnModifierKeyInfoVector.clear();
-
-	std::vector<uint32_t> mouseTurnModifierCombo = ParseKeyCombo(in_combo);
-
-	for (auto& key : mouseTurnModifierCombo)
-	{
-		KeyBindingInfo curkey = { key, false };
-		TurnModifierKeyInfoVector.push_back(curkey);
-	}
-
-	return TurnModifierKeyInfoVector.size() > 0;
+	mouseTurnModifierCombo.clear();
+	mouseTurnModifierCombo = ParseKeyCombo(in_combo);
+	return mouseTurnModifierCombo.size() > 0;
 }
 
 bool bPrevMouseTurnState = false;
 bool bMouseTurnStateChanged = false;
 
-void isMouseTurnEnabled(UINT uMsg, WPARAM wParam)
+bool isMouseTurnEnabled()
 {
-	modifierPressed = IsComboKeyPressed(&TurnModifierKeyInfoVector, uMsg, wParam);
+	bool modifierPressed = IsComboKeyPressed(&mouseTurnModifierCombo);
 
 	bool state = cfg.bUseMouseTurning;
 
@@ -73,9 +65,16 @@ void isMouseTurnEnabled(UINT uMsg, WPARAM wParam)
 		state = !state;
 
 	bMouseTurnStateChanged = bPrevMouseTurnState != state;
+
+	if (bMouseTurnStateChanged)
+	{
+		*(float*)(ptrCamXPosAddr) = 0.0f;
+		*(int8_t*)(ptrCamXmovAddr) = 0;
+	}
+
 	bPrevMouseTurnState = state;
 
-	shouldMouseTurn = state;
+	return state;
 }
 
 // Enable the turning animation if the mouse is moving and we're not
@@ -91,7 +90,7 @@ void __declspec(naked) TurnRightAnimHook()
 
 	if ((GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
 	{
-		if (shouldMouseTurn && (intMouseDeltaX() > 0))
+		if (isMouseTurnEnabled() && (intMouseDeltaX() > 0))
 			if ((intMovInputState() != 0x01) && (intMovInputState() != 0x02) && (intMovInputState() != 0x41) && (intMovInputState() != 0x42))
 				_EAX = 0x1;
 	}
@@ -122,7 +121,7 @@ void __declspec(naked) TurnLeftAnimHook()
 
 	if ((GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
 	{
-		if (shouldMouseTurn && (intMouseDeltaX() < 0))
+		if (isMouseTurnEnabled() && (intMouseDeltaX() < 0))
 			if ((intMovInputState() != 0x01) && (intMovInputState() != 0x02) && (intMovInputState() != 0x41) && (intMovInputState() != 0x42))
 				_EAX = 0x1;
 	}
@@ -156,7 +155,7 @@ void __declspec(naked) MotionMoveHook1()
 	}
 	else
 	{
-		if (shouldMouseTurn)
+		if (isMouseTurnEnabled())
 		{
 			if (isTurn && (intMovInputState() != 0x00))
 				_asm {call ptrPSVECAdd}
@@ -193,7 +192,7 @@ void __declspec(naked) MotionMoveHook2()
 	}
 	else
 	{
-		if (shouldMouseTurn)
+		if (isMouseTurnEnabled())
 		{
 			if (isTurn && (intMouseDeltaX() == 0))
 				_asm {call ptrPSVECAdd}
@@ -232,6 +231,9 @@ void GetMouseTurnPointers()
 	auto pattern = hook::pattern("DB 05 ? ? ? ? D9 45 ? D9 C0 DE CA D9 C5");
 	ptrMouseDeltaX = *pattern.count(1).get(0).get<uint32_t*>(2);
 
+	pattern = hook::pattern("A2 ? ? ? ? EB ? DD D8 8B 0D ? ? ? ? 8B 81 ? ? ? ? A9");
+	ptrCamXmovAddr = *pattern.count(1).get(0).get<uint32_t*>(1);
+
 	pattern = hook::pattern("A1 ? ? ? ? 25 ? ? ? ? 33 C9 0B C1 74 ? B8 ? ? ? ? C3");
 	ptrMovInputState = *pattern.count(1).get(0).get<uint32_t*>(1);
 
@@ -246,60 +248,29 @@ void Init_MouseTurning()
 {
 	GetMouseTurnPointers();
 
-	// Camera control
-	auto pattern = hook::pattern("A2 ? ? ? ? EB ? DD D8 8B 0D ? ? ? ? 8B 81 ? ? ? ? A9");
-	ptrCamXmovAddr = *pattern.count(1).get(0).get<uint32_t*>(1);
-	struct CameraControl1
+	// Key CameraXpos at 0f while isMouseTurnEnabled
+	auto pattern = hook::pattern("D9 05 ? ? ? ? DE C2 D9 C9 D9 1D ? ? ? ? D9 85");
+	ptrCamXPosAddr = *pattern.count(1).get(0).get<uint32_t*>(2);
+	struct CameraPositionWriter
 	{
 		void operator()(injector::reg_pack& regs)
 		{
-			if (bMouseTurnStateChanged)
-				*(int8_t*)(ptrCamXmovAddr) = 0;
+			float CameraXpos;
 
-			if (!shouldMouseTurn || modifierPressed || (GetLastUsedDevice() == LastDevice::XinputController) || (GetLastUsedDevice() == LastDevice::DinputController))
-				*(int8_t*)(ptrCamXmovAddr) = (int8_t)regs.eax;
+			if ((GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
+			{
+				if (isMouseTurnEnabled())
+					CameraXpos = 0.0f;
+				else
+					CameraXpos = *(float*)(ptrCamXPosAddr);
+			}
+			else
+				CameraXpos = *(float*)(ptrCamXPosAddr);
+
+			_asm {fld CameraXpos}
+
 		}
-	}; injector::MakeInline<CameraControl1>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
-
-	pattern = hook::pattern("C6 05 ? ? ? ? ? EB ? 83 F8 ? 7D ? C6 05 ? ? ? ? ? EB ? E8");
-	struct CameraControl2
-	{
-		void operator()(injector::reg_pack& regs)
-		{
-			if (bMouseTurnStateChanged)
-				*(int8_t*)(ptrCamXmovAddr) = 0;
-
-			if (!shouldMouseTurn || modifierPressed || (GetLastUsedDevice() == LastDevice::XinputController) || (GetLastUsedDevice() == LastDevice::DinputController))
-				*(int8_t*)(ptrCamXmovAddr) = 0x7F;
-		}
-	}; injector::MakeInline<CameraControl2>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
-
-	pattern = hook::pattern("C6 05 ? ? ? ? ? EB ? E8 ? ? ? ? EB");
-	struct CameraControl3
-	{
-		void operator()(injector::reg_pack& regs)
-		{
-			if (bMouseTurnStateChanged)
-				*(int8_t*)(ptrCamXmovAddr) = 0;
-
-			if (!shouldMouseTurn || modifierPressed || (GetLastUsedDevice() == LastDevice::XinputController) || (GetLastUsedDevice() == LastDevice::DinputController))
-				*(int8_t*)(ptrCamXmovAddr) = -0x7F;
-		}
-	}; injector::MakeInline<CameraControl3>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
-
-	// Always center the camera behind the character
-	pattern = hook::pattern("8B 16 8B 42 ? 8B CE FF D0 8B CE E8 ? ? ? ? 8B CE E8 ? ? ? ? 8B CE");
-	struct CameraAutoCenter
-	{
-		void operator()(injector::reg_pack& regs)
-		{
-			regs.edx = *(int32_t*)(regs.esi);
-			regs.eax = *(int32_t*)(regs.edx + 0x54);
-
-			if ((shouldMouseTurn || bMouseTurnStateChanged) && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
-				regs.edi = 1;
-		}
-	}; injector::MakeInline<CameraAutoCenter>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
+	}; injector::MakeInline<CameraPositionWriter>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
 
 	// Turning animations
 	// Trigger left turn
@@ -336,7 +307,7 @@ void Init_MouseTurning()
 		{
 			regs.eax = *(int8_t*)(regs.esi + 0xFE);
 
-			if (shouldMouseTurn && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
+			if (isMouseTurnEnabled() && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
 				MouseTurn();
 		}
 	}; injector::MakeInline<TurnHookStill>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
@@ -353,7 +324,7 @@ void Init_MouseTurning()
 		{
 			regs.eax = intMovInputState();
 
-			if (shouldMouseTurn && (intMouseDeltaX() < -8))
+			if (isMouseTurnEnabled() && (intMouseDeltaX() < -8))
 				regs.eax = 0x8;
 
 			isTurn = true;
@@ -367,7 +338,7 @@ void Init_MouseTurning()
 		{
 			regs.eax = intMovInputState();
 
-			if (shouldMouseTurn && (intMouseDeltaX() > 8))
+			if (isMouseTurnEnabled() && (intMouseDeltaX() > 8))
 				regs.eax = 0x4;
 
 			isTurn = true;
@@ -382,7 +353,7 @@ void Init_MouseTurning()
 			regs.ebp = *(int32_t*)(regs.esp);
 			*(int32_t*)(regs.esp) -= 0x8;
 
-			if (shouldMouseTurn && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
+			if (isMouseTurnEnabled() && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
 				MouseTurn();
 		}
 	};
@@ -401,7 +372,7 @@ void Init_MouseTurning()
 	{
 		void operator()(injector::reg_pack& regs)
 		{
-			if (shouldMouseTurn && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
+			if (isMouseTurnEnabled() && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
 				MouseTurn();
 		}
 	}; injector::MakeInline<TurnHookWalkingBack>(pattern.count(3).get(1).get<uint32_t>(0), pattern.count(3).get(1).get<uint32_t>(7));
@@ -415,7 +386,7 @@ void Init_MouseTurning()
 		void operator()(injector::reg_pack& regs)
 		{
 			regs.eax = *(int32_t*)ptrKnife_r3_downMovAddr;
-			if (shouldMouseTurn && (intMouseDeltaX() != 0) && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
+			if (isMouseTurnEnabled() && (intMouseDeltaX() != 0) && (GetLastUsedDevice() == LastDevice::Keyboard) || (GetLastUsedDevice() == LastDevice::Mouse))
 				regs.eax = 0x8;
 		}
 	}; injector::MakeInline<Knife_r3_downHook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));

--- a/dllmain/MouseTurning.h
+++ b/dllmain/MouseTurning.h
@@ -1,5 +1,4 @@
 #pragma once
 
 void Init_MouseTurning();
-void isMouseTurnEnabled(UINT uMsg, WPARAM wParam);
 bool ParseMouseTurnModifierCombo(std::string_view in_combo);

--- a/dllmain/MouseTurning.h
+++ b/dllmain/MouseTurning.h
@@ -1,4 +1,5 @@
 #pragma once
 
 void Init_MouseTurning();
+void isMouseTurnEnabled(UINT uMsg, WPARAM wParam);
 bool ParseMouseTurnModifierCombo(std::string_view in_combo);

--- a/dllmain/MouseTurning.h
+++ b/dllmain/MouseTurning.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void Init_MouseTurning();
+bool ParseMouseTurnModifierCombo(std::string_view in_combo);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -187,6 +187,19 @@ std::unordered_map<std::string, key_type> key_map
 	{ "#",	{ VK_OEM_7, 0 } },  // UK keyboard
 	{ "\"", { VK_OEM_7, 0 } },  // UK keyboard
 	{ "`",	{ VK_OEM_8, 0 } },  // UK keyboard
+
+	// Mouse
+	{ "LMOUSE", { VK_LBUTTON, 0 } },
+	{ "RMOUSE", { VK_RBUTTON, 0 } },
+	{ "MMOUSE", { VK_MBUTTON, 0 } },
+	{ "LCLICK", { VK_LBUTTON, 0 } },
+	{ "RCLICK", { VK_RBUTTON, 0 } },
+	{ "MCLICK", { VK_MBUTTON, 0 } },
+	{ "MOUSE1", { VK_LBUTTON, 0 } },
+	{ "MOUSE2", { VK_RBUTTON, 0 } },
+	{ "MOUSE3", { VK_MBUTTON, 0 } },
+	{ "MOUSE4", { VK_XBUTTON1, 0 } },
+	{ "MOUSE5", { VK_XBUTTON2, 0 } }
 };
 
 bool IsComboKeyPressed(std::vector<KeyBindingInfo> *KeyInfo, UINT uMsg, WPARAM wParam)

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -214,7 +214,7 @@ bool IsComboKeyPressed(std::vector<KeyBindingInfo> *KeyInfo, UINT uMsg, WPARAM w
 	if (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP)
 		return false;
 
-	bool isComboPressed = true;
+	bool isComboPressed = KeyInfo->size() > 0;
 	for (auto& key : *KeyInfo)
 	{
 		if (!key.isPressed)
@@ -378,6 +378,8 @@ void Settings::ReadSettings()
 		ParseToolMenuKeyCombo(cfg.sDebugMenuKeyCombo);
 
 	cfg.sMouseTurnModifierKeyCombo = iniReader.ReadString("HOTKEYS", "MouseTurnModifier", "ALT");
+	if (cfg.sMouseTurnModifierKeyCombo.length())
+		ParseMouseTurnModifierCombo(cfg.sMouseTurnModifierKeyCombo);
 
 	// FPS WARNING
 	cfg.bIgnoreFPSWarning = iniReader.ReadBoolean("WARNING", "IgnoreFPSWarning", false);
@@ -481,7 +483,7 @@ void Settings::WriteSettings()
 	iniReader.WriteString("HOTKEYS", "ConfigMenu", " " + cfg.sConfigMenuKeyCombo);
 	iniReader.WriteString("HOTKEYS", "Console", " " + cfg.sConsoleKeyCombo);
 	iniReader.WriteString("HOTKEYS", "DebugMenu", " " + cfg.sDebugMenuKeyCombo);
-	iniReader.WriteString("HOTKEYS", "MouseTurnModifier", " " + cfg.sDebugMenuKeyCombo);
+	iniReader.WriteString("HOTKEYS", "MouseTurnModifier", " " + cfg.sMouseTurnModifierKeyCombo);
 
 	// IMGUI
 	iniReader.WriteFloat("IMGUI", "FontSize", cfg.fFontSize);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -191,9 +191,6 @@ std::unordered_map<std::string, key_type> key_map
 
 bool IsComboKeyPressed(std::vector<KeyBindingInfo> *KeyInfo, UINT uMsg, WPARAM wParam)
 {
-	if ((uMsg != WM_KEYDOWN) && (uMsg != WM_SYSKEYDOWN) && (uMsg != WM_KEYUP) && (uMsg != WM_SYSKEYUP))
-		return false;
-
 	for (auto& key : *KeyInfo)
 	{
 		// Left Alt (VK_LMENU) seems to actually be VK_MENU when sent via WM_SYSKEYDOWN

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -384,7 +384,12 @@ void Settings::ReadSettings()
 
 	cfg.sConsoleKeyCombo = iniReader.ReadString("HOTKEYS", "Console", "F2");
 	if (cfg.sConsoleKeyCombo.length())
+	{
 		ParseConsoleKeyCombo(cfg.sConsoleKeyCombo);
+
+		// Update console title
+		con.TitleKeyCombo = cfg.sConsoleKeyCombo;
+	}
 
 	cfg.sDebugMenuKeyCombo = iniReader.ReadString("HOTKEYS", "DebugMenu", "CTRL+F3");
 	if (cfg.sDebugMenuKeyCombo.length())

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -202,44 +202,6 @@ std::unordered_map<std::string, key_type> key_map
 	{ "MOUSE5", { VK_XBUTTON2, 0 } }
 };
 
-bool IsComboKeyPressed(std::vector<KeyBindingInfo> *KeyInfo, UINT uMsg, WPARAM wParam)
-{
-	for (auto& key : *KeyInfo)
-	{
-		// Left Alt (VK_LMENU) seems to actually be VK_MENU when sent via WM_SYSKEYDOWN
-		if ((uMsg == WM_SYSKEYDOWN) && (key.id == VK_LMENU))
-			key.id = VK_MENU;
-
-		switch (uMsg) {
-		case WM_KEYDOWN:
-		case WM_SYSKEYDOWN: // Also handle WM_SYSKEYxx since Alt sends that for some reason
-			if (wParam == key.id)
-				key.isPressed = true;
-			break;
-		case WM_KEYUP:
-		case WM_SYSKEYUP:
-			if (wParam == key.id)
-				key.isPressed = false;
-			break;
-		}
-	}
-
-	if (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP)
-		return false;
-
-	bool isComboPressed = KeyInfo->size() > 0;
-	for (auto& key : *KeyInfo)
-	{
-		if (!key.isPressed)
-		{
-			isComboPressed = false;
-			break;
-		}
-	}
-
-	return isComboPressed;
-}
-
 std::vector<uint32_t> ParseKeyCombo(std::string_view in_combo)
 {
 	// Convert combo to uppercase to match Settings::key_map

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -390,7 +390,7 @@ void Settings::ReadSettings()
 	if (cfg.sDebugMenuKeyCombo.length())
 		ParseToolMenuKeyCombo(cfg.sDebugMenuKeyCombo);
 
-	cfg.sMouseTurnModifierKeyCombo = iniReader.ReadString("HOTKEYS", "MouseTurnModifier", "ALT");
+	cfg.sMouseTurnModifierKeyCombo = iniReader.ReadString("HOTKEYS", "MouseTurningModifier", "ALT");
 	if (cfg.sMouseTurnModifierKeyCombo.length())
 		ParseMouseTurnModifierCombo(cfg.sMouseTurnModifierKeyCombo);
 
@@ -496,7 +496,7 @@ void Settings::WriteSettings()
 	iniReader.WriteString("HOTKEYS", "ConfigMenu", " " + cfg.sConfigMenuKeyCombo);
 	iniReader.WriteString("HOTKEYS", "Console", " " + cfg.sConsoleKeyCombo);
 	iniReader.WriteString("HOTKEYS", "DebugMenu", " " + cfg.sDebugMenuKeyCombo);
-	iniReader.WriteString("HOTKEYS", "MouseTurnModifier", " " + cfg.sMouseTurnModifierKeyCombo);
+	iniReader.WriteString("HOTKEYS", "MouseTurningModifier", " " + cfg.sMouseTurnModifierKeyCombo);
 
 	// IMGUI
 	iniReader.WriteFloat("IMGUI", "FontSize", cfg.fFontSize);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <vector>
 
+// Parses an key combination string into a vector of VKs
+std::vector<uint32_t> ParseKeyCombo(std::string_view in_combo);
 
 // Globals
 struct Settings
@@ -32,6 +34,7 @@ struct Settings
 	bool bSkipIntroLogos;
 	bool bEnableDebugMenu;
 	std::string sDebugMenuKeyCombo;
+	std::string sMouseTurnModifierKeyCombo;
 	float fControllerSensitivity;
 	bool bEnableControllerSens;
 	bool bUseMouseTurning;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -2,11 +2,6 @@
 #include <iostream>
 #include <vector>
 
-struct KeyBindingInfo {
-	uint32_t id;
-	bool isPressed;
-};
-
 // Globals
 struct Settings
 {
@@ -69,8 +64,5 @@ struct Settings
 
 // Parses an key combination string into a vector of VKs
 std::vector<uint32_t> ParseKeyCombo(std::string_view in_combo);
-
-// Checks if a key combo is being pressed
-bool IsComboKeyPressed(std::vector<KeyBindingInfo>* KeyInfo, UINT uMsg, WPARAM wParam);
 
 extern Settings cfg;

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -41,57 +41,10 @@ void* DbgFont = nullptr;
 // Default tool-menu keyboard combo is currently LCONTROL + F3
 std::vector<uint32_t> toolMenuKeyCombo = { VK_LCONTROL, VK_F3 };
 
-// Parses an key combination string into the toolMenuKeyCombo vector, to be checked by tool-menu opening code
 bool ParseToolMenuKeyCombo(std::string_view in_combo)
 {
-	// Convert combo to uppercase to match Settings::key_map
-	std::string combo(in_combo);
-	std::transform(combo.begin(), combo.end(), combo.begin(),
-		[](unsigned char c) { return std::toupper(c); });
-
-	std::vector<uint32_t> new_combo;
-	std::string cur_token;
-
-	// Parse combo tokens into buttons bitfield (tokens seperated by any
-	// non-alphabetical char, eg. +)
-	for (size_t i = 0; i < combo.length(); i++)
-	{
-		char c = combo[i];
-
-		if (!isalpha(c) && (c < 0x30 || c > 0x39) && c != '-')
-		{
-			// seperator, try parsing previous token
-
-			if (cur_token.length())
-			{
-				uint32_t token_num = cfg.KeyMap(cur_token.c_str(), true);
-				if (!token_num)
-					return false; // parse failed...
-				new_combo.push_back(token_num);
-			}
-
-			cur_token.clear();
-		}
-		else
-		{
-			// Must be a character key, convert to upper and add to our cur_token
-			cur_token += ::toupper(c);
-		}
-	}
-
-	if (cur_token.length())
-	{
-		uint32_t token_num = cfg.KeyMap(cur_token.c_str(), true);
-		if (!token_num)
-			return false; // parse failed...
-		new_combo.push_back(token_num);
-	}
-
-	if (new_combo.size() <= 0)
-		return false; // failed to parse/update combo, return so we'll keep previous one
-
-	toolMenuKeyCombo = new_combo;
-	return true;
+	toolMenuKeyCombo = ParseKeyCombo(in_combo);
+	return toolMenuKeyCombo.size() > 0;
 }
 
 struct ToolMenuEntry

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -5,6 +5,7 @@
 #include "dllmain.h"
 #include "ConsoleWnd.h"
 #include "Settings.h"
+#include "WndProcHook.h"
 
 // Light tool externs
 void LightTool_GetPointers();
@@ -36,29 +37,14 @@ uint32_t* roomInfoAddr = nullptr;
 void* cDvd = nullptr;
 void* DbgFont = nullptr;
 
-bool DebugComboPressed;
+// Default tool-menu keyboard combo is currently LCONTROL + F3
+std::vector<uint32_t> toolMenuKeyCombo;
 
-std::vector<KeyBindingInfo> toolMenuKeyInfoVector;
-
-// Reads the key combo into an array containing the key id and isPressed state
 bool ParseToolMenuKeyCombo(std::string_view in_combo)
 {
-	toolMenuKeyInfoVector.clear();
-
-	std::vector<uint32_t> DebugMenuCombo = ParseKeyCombo(in_combo);
-
-	for (auto& key : DebugMenuCombo)
-	{
-		KeyBindingInfo curkey = { key, false };
-		toolMenuKeyInfoVector.push_back(curkey);
-	}
-
-	return toolMenuKeyInfoVector.size() > 0;
-}
-
-void ToolMenuBinding(UINT uMsg, WPARAM wParam)
-{
-	DebugComboPressed = IsComboKeyPressed(&toolMenuKeyInfoVector, uMsg, wParam);
+	toolMenuKeyCombo.clear();
+	toolMenuKeyCombo = ParseKeyCombo(in_combo);
+	return toolMenuKeyCombo.size() > 0;
 }
 
 struct ToolMenuEntry
@@ -191,8 +177,12 @@ void __cdecl gameDebug_recreation(void* a1)
 		{
 			// check for toolMenuKeyCombo
 
-			if (toolMenuKeyInfoVector.size() > 0)
-				isOnlyDebugComboPressed = DebugComboPressed; // seperate bools to be safe...
+			if (toolMenuKeyCombo.size() > 0)
+			{
+				bool openToolMenu = IsComboKeyPressed(&toolMenuKeyCombo);
+
+				isOnlyDebugComboPressed = openToolMenu; // seperate bools to be safe...
+			}
 		}
 
 		if (isOnlyDebugComboPressed)

--- a/dllmain/ToolMenu.h
+++ b/dllmain/ToolMenu.h
@@ -2,5 +2,4 @@
 
 void Init_ToolMenu();
 void Init_ToolMenuDebug();
-void ToolMenuBinding(UINT uMsg, WPARAM wParam);
 bool ParseToolMenuKeyCombo(std::string_view in_combo);

--- a/dllmain/WndProcHook.cpp
+++ b/dllmain/WndProcHook.cpp
@@ -56,22 +56,26 @@ int curPosX;
 int curPosY;
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	// Evaluate mouse turning state
-	isMouseTurnEnabled(uMsg, wParam);
-	
-	// Key bindings for flipping inventory items on keyboard
-	InventoryFlipBindings(uMsg, wParam);
+	// Send key events where necessary
+	if ((uMsg == WM_KEYDOWN) || (uMsg == WM_SYSKEYDOWN) || (uMsg == WM_KEYUP) || (uMsg == WM_SYSKEYUP))
+	{
+		// Evaluate mouse turning state
+		isMouseTurnEnabled(uMsg, wParam);
 
-	// Key binding for brining up the config menu
-	cfgMenuBinding(hWindow, uMsg, wParam, lParam);
+		// Key bindings for flipping inventory items on keyboard
+		InventoryFlipBindings(uMsg, wParam);
 
-	// Key binding for brining up the config menu
-	ToolMenuBinding(uMsg, wParam);
+		// Key binding for brining up the config menu
+		cfgMenuBinding(hWindow, uMsg, wParam, lParam);
 
-	#ifdef VERBOSE
-	// Key binding for showing/hiding the console window
-	ConsoleBinding(uMsg, wParam);
-	#endif
+		// Key binding for brining up the config menu
+		ToolMenuBinding(uMsg, wParam);
+
+		#ifdef VERBOSE
+		// Key binding for showing/hiding the console window
+		ConsoleBinding(uMsg, wParam);
+		#endif
+	}
 
 	switch (uMsg) {
 		case WM_MOVE:

--- a/dllmain/WndProcHook.cpp
+++ b/dllmain/WndProcHook.cpp
@@ -7,6 +7,7 @@
 #include "ConsoleWnd.h"
 #include "../external/imgui/imgui.h"
 #include "LAApatch.h"
+#include "MouseTurning.h"
 
 WNDPROC oWndProc;
 HWND hWindow;
@@ -53,6 +54,9 @@ int curPosX;
 int curPosY;
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+	// Evaluate mouse turning state
+	isMouseTurnEnabled(uMsg, wParam);
+
 	switch (uMsg) {
 		case WM_KEYUP:
 			if (wParam == cfg.KeyMap(cfg.flip_item_left.data(), true) || wParam == cfg.KeyMap(cfg.flip_item_right.data(), true))

--- a/dllmain/WndProcHook.h
+++ b/dllmain/WndProcHook.h
@@ -1,5 +1,12 @@
 #pragma once
 
+struct key_state
+{
+	bool pressed = false;
+	bool changed = false;
+};
+
 void Init_WndProcHook();
+bool IsComboKeyPressed(std::vector<uint32_t>* KeyVector);
 
 extern HWND hWindow;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -622,7 +622,6 @@ void MenuRender()
 
 				// MouseTurningModifier bindings
 				ImGui::TextWrapped("MouseTurning camera modifier. When holding this key combination, MouseTurning is temporarily activated/deactivated.");
-				ImGui::TextWrapped("Requires MouseTurning to be enabled.");
 
 				ImGui::PushItemWidth(100);
 				ImGui::InputText("MouseTurning modifier", &cfg.sMouseTurnModifierKeyCombo, ImGuiInputTextFlags_CharsUppercase);

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -14,6 +14,7 @@
 #include <hashes.h>
 #include <sffont.hpp>
 #include <faprolight.hpp>
+#include "MouseTurning.h"
 
 uintptr_t ptrInputProcess;
 uintptr_t* ptrD3D9Device;
@@ -143,6 +144,7 @@ void MenuRender()
 				ParseConsoleKeyCombo(cfg.sConsoleKeyCombo);
 				ParseToolMenuKeyCombo(cfg.sDebugMenuKeyCombo);
 				ParseConfigMenuKeyCombo(cfg.sConfigMenuKeyCombo);
+				ParseMouseTurnModifierCombo(cfg.sMouseTurnModifierKeyCombo);
 
 				cfg.fFontSize = ImGui::GetIO().FontGlobalScale + 0.35f;
 				cfg.WriteSettings();
@@ -615,6 +617,21 @@ void MenuRender()
 
 				ImGui::PushItemWidth(100);
 				ImGui::InputText("Open debug menu", &cfg.sDebugMenuKeyCombo, ImGuiInputTextFlags_CharsUppercase);
+				ImGui::PopItemWidth;
+
+				if (ImGui::IsItemEdited())
+					cfg.HasUnsavedChanges = true;
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
+				// MouseTurningModifier bindings
+				ImGui::TextWrapped("MouseTurning camera modifier. When holding this key combination, MouseTurning is temporarily activated/deactivated.");
+				ImGui::TextWrapped("Requires MouseTurning to be enabled.");
+
+				ImGui::PushItemWidth(100);
+				ImGui::InputText("MouseTurning modifier", &cfg.sMouseTurnModifierKeyCombo, ImGuiInputTextFlags_CharsUppercase);
 				ImGui::PopItemWidth;
 
 				if (ImGui::IsItemEdited())

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -146,6 +146,9 @@ void MenuRender()
 				ParseConfigMenuKeyCombo(cfg.sConfigMenuKeyCombo);
 				ParseMouseTurnModifierCombo(cfg.sMouseTurnModifierKeyCombo);
 
+				// Update console title
+				con.TitleKeyCombo = cfg.sConsoleKeyCombo;
+
 				cfg.fFontSize = ImGui::GetIO().FontGlobalScale + 0.35f;
 				cfg.WriteSettings();
 			}

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -25,27 +25,18 @@ int MenuTipTimer = 500; // cfgMenu tooltip timer
 
 int Tab = 1;
 
-std::vector<KeyBindingInfo> cfgMenuKeyInfoVector;
+std::vector<uint32_t> cfgMenuCombo;
 
-// Reads the key combo into an array containing the key id and isPressed state
 bool ParseConfigMenuKeyCombo(std::string_view in_combo)
 {
-	cfgMenuKeyInfoVector.clear();
-
-	std::vector<uint32_t> cfgMenuCombo = ParseKeyCombo(in_combo);
-
-	for (auto& key : cfgMenuCombo)
-	{
-		KeyBindingInfo curkey = { key, false };
-		cfgMenuKeyInfoVector.push_back(curkey);
-	}
-
-	return cfgMenuKeyInfoVector.size() > 0;
+	cfgMenuCombo.clear();
+	cfgMenuCombo = ParseKeyCombo(in_combo);
+	return cfgMenuCombo.size() > 0;
 }
 
-void cfgMenuBinding(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+void cfgMenuBinding(HWND hWnd, LPARAM lParam)
 {
-	if (IsComboKeyPressed(&cfgMenuKeyInfoVector, uMsg, wParam))
+	if (IsComboKeyPressed(&cfgMenuCombo))
 	{
 		bCfgMenuOpen = !bCfgMenuOpen;
 

--- a/dllmain/cfgMenu.h
+++ b/dllmain/cfgMenu.h
@@ -2,7 +2,7 @@
 #include "..\includes\stdafx.h"
 
 void Init_cfgMenu();
-void cfgMenuBinding(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+void cfgMenuBinding(HWND hWnd, LPARAM lParam);
 bool ParseConfigMenuKeyCombo(std::string_view in_combo);
 
-LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -151,7 +151,6 @@ Console = F2
 DebugMenu = CTRL+F3
 
 ; MouseTurning camera modifier. When holding this key combination, MouseTurning is temporarily activated/deactivated.
-; Requires MouseTurning to be enabled.
 MouseTurningModifier = ALT
 
 [WARNING]

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -150,6 +150,10 @@ Console = F2
 ; Requires EnableDebugMenu to be enabled.
 DebugMenu = CTRL+F3
 
+; MouseTurning camera modifier. When holding this key combination, MouseTurning is temporarily activated/deactivated.
+; Requires MouseTurning to be enabled.
+MouseTurningModifier = ALT
+
 [WARNING]
 ; This version of RE4 only works properly if played at 30 or 60 FPS. Anything else can and will cause numerous amounts of
 ; different bugs, most of which aren't even documented. By default, re4_tweaks will warn you about these issues and change


### PR DESCRIPTION
From discussion at #83

Using WndProc to get the states would be a lot better, atm there's an issue with bMouseTurnStateChanged where that's only valid for the first `MouseTurnEnabled()` call after state changed, after it's been called once it'll end up resetting the state changed bool at the next call to it (so if that's used more than 1 time in a frame it'd get wrong info), WndProc should let us set that up seperately to all the MouseTurn calls though.

E: oh I missed @RiasatSalminSami's suggestion in that thread:
>-If new mouse controls are enabled: Then the modifier key will switch the mouse controls to default vanilla controls.
>-If new mouse controls are disabled: Then the modifier key will switch the mouse controls to new one.

That's pretty smart actually, so modifier key just inverts the `UseMouseTurning` setting pretty much, and users could still disable it all by clearing key combination (is ALT used by anything in vanilla game btw? would be nice to have that as default)