### PR TITLE
Add GitHub Actions workflow to build the project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          submodules: "recursive"
+          submodules: recursive
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -33,10 +33,16 @@ jobs:
         run: |
           msbuild re4_tweaks.sln /p:Configuration=Release /p:PostBuildEventUseInBuild=false
 
+      - name: Create default configuration file
+        shell: bash
+        run: |
+          head -n -1 settings/settings_string.h | tail -n +3 > dinput8.ini
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
           path: |
             Debug/dinput8.dll
             Release/dinput8.dll
+            dinput8.ini
           name: re4_tweaks_${{ github.head_ref || github.ref_name }}_${{ steps.date.outputs.date }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build Debug and Release
+    runs-on: windows-latest
+
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d_%H%M%S')"
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build Debug
+        run: |
+          msbuild re4_tweaks.sln /p:Configuration=Debug /p:PostBuildEventUseInBuild=false
+
+      - name: Build Release
+        run: |
+          msbuild re4_tweaks.sln /p:Configuration=Release /p:PostBuildEventUseInBuild=false
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            Debug/dinput8.dll
+            Release/dinput8.dll
+          name: re4_tweaks_${{ github.head_ref || github.ref_name }}_${{ steps.date.outputs.date }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           msbuild re4_tweaks.sln /p:Configuration=Debug /p:PostBuildEventUseInBuild=false
 
+      - name: Remove VERBOSE
+        shell: bash
+        run: |
+          sed -i "s/#define VERBOSE//" dllmain/dllmain.h
+
       - name: Build Release
         run: |
           msbuild re4_tweaks.sln /p:Configuration=Release /p:PostBuildEventUseInBuild=false


### PR DESCRIPTION
Thanks for all the hard work! I'm not familiar with C++ and reverse engineering, so I tried to find another way to contribute.

This adds a GitHub Actions workflow to automatically build the project (with both `Debug` and `Release` configurations) and upload both DLL outputs as an artifact. Might be useful to let other people test new commits and PRs, while also ensuring reproducible builds of the project.

I don't know if this setup is sufficient, though. I might be missing some options to `msbuild`.

We can also automate the release with something like [action-gh-release](https://github.com/softprops/action-gh-release), but I suppose you probably want to do it manually so you can test things out ~~(and add the `.ini` as it seems to be written manually?)~~

The result is something like this (you can download the artifact): https://github.com/laymonage/re4_tweaks/actions/runs/1822496969

Let me know if you want me to make adjustments or add some other steps to the build process.