### PR TITLE
Use `windows-2022` build image on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build Debug and Release
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Get current date


### PR DESCRIPTION
This should fix the build. Context: https://github.com/nipkownix/re4_tweaks/pull/102#issuecomment-1035674261