### PR TITLE
Add patch to allow physics on tactical vest

### DIFF
--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -479,6 +479,15 @@ void Init_Main()
 		uint32_t* g_item_price_tbl_num = pattern.count(1).get(0).get<uint32_t>(0);
 		*g_item_price_tbl_num += 1;
 	}
+
+	// Allow physics to apply to tactical vest outfit
+	// Some reason they specifically excluded that outfit inside the physics functions, maybe there's an issue with it somewhere
+	// (Raz0r trainer overwrites this patch every frame for some reason, too bad)
+	{
+		auto pattern = hook::pattern("80 B8 C9 4F 00 00 02 74");
+		injector::MakeNOP(pattern.count(2).get(0).get<uint8_t>(7), 2);
+		injector::MakeNOP(pattern.count(2).get(1).get<uint8_t>(7), 2);
+	}
 }
 
 void LoadRealDLL(HMODULE hModule)


### PR DESCRIPTION
Includes the patch mentioned at https://github.com/nipkownix/re4_tweaks/issues/22#issuecomment-980542000, patching both `cPlLeon::initCloth` & `cPlLeon::moveCloth` (thanks to @RiasatSalminSami for reminding us about it!)

I still think it's weird they included code to check for this costume specifically though, doesn't seem that accidental to me - but since the patch mostly seems to work fine I guess we should be good, if anyone does find a problem with it we can probably just add a check for whatever edge-case has issues with it instead.

If anyone wants to test this, a build with this + RaiseInventoryAlloc fixes is at https://github.com/nipkownix/re4_tweaks/files/8055010/dinput8-tacticalVestPhysics.zip

As noted at https://github.com/nipkownix/re4_tweaks/issues/22#issuecomment-1037799043 Raz0r's trainer seems to overwrite the area that this patches, undoing it every frame, not sure if that can be worked around at all - but that makes me wonder if there could be other patches of ours that it overwrites too...