### PR TITLE
FixAshleyBustPhysics: fixes framerate difference on physics applied to Ashley

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -336,6 +336,7 @@ void Settings::ReadSettings()
 	// FRAME RATE
 	cfg.bFixFallingItemsSpeed = iniReader.ReadBoolean("FRAME RATE", "FixFallingItemsSpeed", true);
 	cfg.bFixQTE = iniReader.ReadBoolean("FRAME RATE", "FixQTE", true);
+	cfg.bFixAshleyBustPhysics = iniReader.ReadBoolean("FRAME RATE", "FixAshleyBustPhysics", true);
 
 	// MEMORY
 	cfg.bAllowHighResolutionSFD = iniReader.ReadBoolean("MEMORY", "AllowHighResolutionSFD", true);
@@ -459,6 +460,7 @@ void Settings::WriteSettings()
 	// FRAME RATE
 	iniReader.WriteBoolean("FRAME RATE", "FixFallingItemsSpeed", cfg.bFixFallingItemsSpeed);
 	iniReader.WriteBoolean("FRAME RATE", "FixQTE", cfg.bFixQTE);
+	iniReader.WriteBoolean("FRAME RATE", "FixAshleyBustPhysics", cfg.bFixAshleyBustPhysics);
 
 	// MEMORY
 	iniReader.WriteBoolean("MEMORY", "AllowHighResolutionSFD", cfg.bAllowHighResolutionSFD);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -49,6 +49,7 @@ struct Settings
 	std::string sQTE_key_2;
 	bool bFixFallingItemsSpeed;
 	bool bFixQTE;
+	bool bFixAshleyBustPhysics;
 	bool bAllowHighResolutionSFD;
 	bool bRaiseVertexAlloc;
 	bool bRaiseInventoryAlloc;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -559,6 +559,14 @@ void MenuRender()
 				cfg.HasUnsavedChanges |= ImGui::Checkbox("FixQTE", &cfg.bFixQTE);
 				ImGui::TextWrapped("When running in 60 FPS, some QTEs require extremely fast button presses to work. This gets even worse in Professional difficulty, making it seem almost impossible to survive the minecart and the statue bridge QTEs.");
 				ImGui::TextWrapped("This fix makes QTEs that involve rapid button presses much more forgiving.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
+				// AshleyBustPhysicsFix
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("FixAshleyBustPhysics", &cfg.bFixAshleyBustPhysics);
+				ImGui::TextWrapped("Fixes difference between 30/60FPS on physics applied to Ashley.");
 			}
 
 			// Memory tab

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -136,6 +136,9 @@ FixFallingItemsSpeed = true
 ; This fix makes QTEs that involve rapid button presses much more forgiving.
 FixQTE = true
 
+; Fixes difference between 30/60FPS on physics applied to Ashley.
+FixAshleyBustPhysics = true
+
 [MEMORY]
 ; Allocate more memory for SFD movie files, and properly scale its resolution display above 512x336.
 ; Not tested beyond 1920x1080.


### PR DESCRIPTION
As explained at https://github.com/nipkownix/re4_tweaks/issues/22#issuecomment-1042438416 there's two functions related to Ashley bust physics, one for player-controlled Ashley & one for follower Ashley, on GC these two funcs are pretty much identical, but on PC it seems they updated the `cSubChar` version to make use of delta-time to fix physics speed at different framerates, but didn't copy that fix over to the `cPlAshley` function for some reason.

This hook pretty much just recreates that delta-time code inside `cPlAshley`, making physics apply at same rate despite framerate being used.

In effect this seems to slow down the physics at 60FPS - making it match the 30FPS physics speed - though I'm not sure if this helps with the main issue people had with 60FPS Ashley physics (maybe they're mostly referring to follower-Ashley, which this patch doesn't affect)

If anyone wants to test this a build is posted at https://github.com/nipkownix/re4_tweaks/issues/22#issuecomment-1042476550 - this hook only affects player-controlled Ashley, follower Ashley should remain unchanged.

(tested against 1.1.0/1.0.6/1.0.6dbg, hook seems to work fine at least)