### PR TITLE
Game.h: move common Game pointers/structs to single header

### DIFF
--- a/dllmain/60fpsFixes.cpp
+++ b/dllmain/60fpsFixes.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 #include "..\includes\stdafx.h"
+#include "Game.h"
 #include "dllmain.h"
 #include "Settings.h"
 #include "ConsoleWnd.h"
 
 static uint32_t* ptrGameFrameRate;
-extern uint8_t** ptrpG; // dllmain.cpp
 
 int intCurrentFrameRate()
 {
@@ -61,11 +61,9 @@ void Init_60fpsFixes()
 			{
 				if (cfg.bFixAshleyBustPhysics)
 				{
-					uint8_t* Global = *ptrpG;
-
 					// Update ebx to make use of delta-time from pG+0x70
 					float ebx = float(regs.ebx);
-					ebx *= *(float*)(Global + 0x70);
+					ebx *= GlobalPtr()->deltaTime_70;
 					regs.ebx = uint32_t(ebx);
 				}
 

--- a/dllmain/ExceptionHandler.cpp
+++ b/dllmain/ExceptionHandler.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "..\includes\stdafx.h"
 #include "dllmain.h"
+#include "Game.h"
 #include "Settings.h"
 #include "ConsoleWnd.h"
 #include <exception.hpp>
@@ -62,7 +63,7 @@ LONG WINAPI CustomUnhandledExceptionFilter(LPEXCEPTION_POINTERS ExceptionInfo)
             {
                 // Add some info of our own. Only game version for now.
                 std::stringstream re4ti;
-                re4ti << "bio4.exe version: " << game_version << std::endl;
+                re4ti << "bio4.exe version: " << GameVersion() << std::endl;
                 strcat(buffer, re4ti.str().data());
 
                 // Write log file

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -1,0 +1,86 @@
+#include "..\includes\stdafx.h"
+#include "Game.h"
+
+std::string gameVersion;
+bool gameIsDebugBuild = false;
+
+std::string GameVersion()
+{
+	return gameVersion;
+}
+
+bool GameVersionIsDebug()
+{
+	return gameIsDebugBuild;
+}
+
+GLOBALS** pG_ptr = nullptr;
+GLOBALS* GlobalPtr()
+{
+	if (!pG_ptr)
+		return nullptr;
+
+	return *pG_ptr;
+}
+
+SYSTEM_SAVE** pSys_ptr = nullptr;
+SYSTEM_SAVE* SystemSavePtr()
+{
+	if (!pSys_ptr)
+		return nullptr;
+
+	return *pSys_ptr;
+}
+
+cPlayer** pPL_ptr = 0;
+cPlayer* PlayerPtr()
+{
+	if (!pPL_ptr)
+		return nullptr;
+
+	return *pPL_ptr;
+}
+
+bool Init_Game()
+{
+	// Detect game version
+	auto pattern = hook::pattern("31 2E ? ? ? 00 00 00 6D 6F 76 69 65 2F 64 65 6D 6F 30 65 6E 67 2E 73 66 64");
+	int ver = injector::ReadMemory<int>(pattern.count(1).get(0).get<uint32_t>(2));
+
+	if (ver == 0x362E30) {
+		gameVersion = "1.0.6";
+	}
+	else if (ver == 0x302E31) {
+		gameVersion = "1.1.0";
+	}
+	else {
+		MessageBoxA(NULL, "This version of RE4 is not supported.\nre4_tweaks will be disabled.", "re4_tweaks", MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND);
+		return false;
+	}
+
+	// Check for part of gameDebug function, if exists this must be a debug-enabled build
+	pattern = hook::pattern("6A 00 6A 00 6A 08 68 AE 01 00 00 6A 10 6A 0A");
+	if (pattern.size() > 0)
+	{
+		gameVersion += "d";
+		gameIsDebugBuild = true;
+	}
+
+#ifdef VERBOSE
+	con.AddConcatLog("Game version = ", game_version.data());
+#endif
+
+	// Grab pointer to pG (pointer to games Global struct)
+	pattern = hook::pattern("A1 ? ? ? ? B9 FF FF FF 7F 21 48 ? A1");
+	pG_ptr = *pattern.count(1).get(0).get<GLOBALS**>(1);
+
+	// pSys pointer
+	pattern = hook::pattern("00 80 00 00 83 C4 ? E8 ? ? ? ? A1 ? ? ? ?");
+	pSys_ptr = *pattern.count(1).get(0).get<SYSTEM_SAVE**>(13);
+
+	// pPL pointer
+	pattern = hook::pattern("A1 ? ? ? ? D8 CC D8 C9 D8 CA D9 5D ? D9 45 ?");
+	pPL_ptr = *pattern.count(1).get(0).get<cPlayer**>(1);
+
+	return true;
+}

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -1,0 +1,337 @@
+#pragma once
+#include <cstdint>
+#include "GameFlags.h"
+
+// From GC SDK?
+typedef struct tagVec // PS2 seems to refer to these via the tag names
+{
+  float x;
+  float y;
+  float z;
+} Vec, Point3d;
+static_assert(sizeof(Vec) == 0xC, "sizeof(Vec)");
+
+typedef struct tagQuaternion
+{
+  float x;
+  float y;
+  float z;
+  float w;
+} Quaternion;
+static_assert(sizeof(Quaternion) == 0x10, "sizeof(Quaternion)");
+
+typedef float Mtx[3][4];
+typedef float Mtx44[4][4];
+typedef float ROMtx[4][3];
+static_assert(sizeof(Mtx) == 0x30, "sizeof(Mtx)");
+static_assert(sizeof(Mtx44) == 0x40, "sizeof(Mtx44)");
+static_assert(sizeof(ROMtx) == 0x30, "sizeof(ROMtx)");
+
+struct GXTexObj
+{
+  uint32_t field_0;
+  uint32_t field_4;
+  uint32_t field_8;
+  uint32_t field_C;
+  uint32_t field_10;
+  uint32_t field_14;
+  uint32_t field_18;
+  uint32_t field_1C;
+};
+static_assert(sizeof(GXTexObj) == 0x20, "sizeof(GXTexObj)"); // seems to be correct size, different to GC/Wii struct?
+
+// Game structs
+struct CAMERA
+{
+  Mtx mtx1_0;
+  Mtx mtx2_30;
+  float field_60;
+  Mtx44 mtx3_64;
+  Vec field_A4;
+  Vec field_B0;
+  float field_BC;
+  float binoZoomLimitRelated_C0; // FOV?
+  Vec field_C4;
+  Vec field_D0;
+  Vec field_DC;
+  float field_E8;
+  float field_EC;
+  float field_F0;
+  float field_F4;
+};
+static_assert(sizeof(CAMERA) == 0xF8, "sizeof(CAMERA)"); // TODO: find if this size is correct
+
+enum EM_BE_FLAG : uint8_t
+{
+  EM_BE_FLAG_ALIVE = 0x1,
+  EM_BE_FLAG_SET = 0x2,
+  EM_BE_FLAG_DIE = 0x80,
+};
+
+struct EM_LIST
+{
+  EM_BE_FLAG be_flag_0;
+  char id_1;
+  char type_2;
+  char set_3;
+  uint32_t em_flag_4;
+  int16_t hp_8;
+  uint8_t gapA;
+  char charaId_B;
+  int16_t posX_C;
+  int16_t posY_E;
+  int16_t posZ_10;
+  int16_t rotX_12;
+  int16_t rotY_14;
+  int16_t rotZ_16;
+  int16_t roomId_18;
+  int16_t guardRadius_1A;
+  uint8_t gap1C[4];
+};
+static_assert(sizeof(EM_LIST) == 0x20, "sizeof(EM_LIST)"); // TODO: find if this size is correct
+
+struct __declspec(align(4)) GLOBALS
+{
+  uint8_t field_0;
+  uint8_t field_1;
+  uint8_t field_2;
+  uint8_t field_3;
+  uint8_t flags_saveRelated_4;
+  uint8_t saveRelated_5;
+  uint8_t saveRelated_6;
+  uint8_t saveRelated_7;
+  uint32_t field_8;
+  uint32_t field_C;
+  void* ptr_romFont_10;
+  uint8_t field_14;
+  uint8_t field_15;
+  uint8_t field_16;
+  uint8_t wideMode_17;
+  uint32_t field_18;
+  uint32_t field_1C;
+  uint8_t field_20;
+  uint8_t field_21;
+  uint8_t field_22;
+  uint8_t field_23;
+  void* field_24;
+  uint16_t nextRoomId_28;
+  uint8_t field_2A;
+  uint8_t field_2B;
+  float field_2C;
+  float field_30;
+  float field_34;
+  float field_38;
+  void* ptr_field_3C;
+  uint8_t* ptr_roomData_40;
+  uint32_t ptr_wepData_44;
+  uint32_t* ptr_coreData_48;
+  uint32_t ptr_optionData_4C;
+  void* ptr_playerData_50;
+  uint32_t flags_SYSTEM_54;
+  uint32_t flags_DISP0_58;
+  uint32_t curGameTime_5C;
+  uint32_t flags_DEBUG_60[4];
+  float deltaTime_70;
+  CAMERA cameraInstance_74;
+  uint32_t field_16C;
+  uint32_t flags_STOP_170;
+  uint32_t flags_ROOM_174;
+  uint32_t field_178;
+  uint32_t field_17C;
+  uint32_t field_180;
+  float weightpaletteext0_184;
+  float weightpaletteext0_188;
+  float weightpaletteext0_18C;
+  float weightpaletteext0_190;
+  float weightpaletteext0_194;
+  float weightpaletteext0_198;
+  float weightpaletteext0_19C;
+  float weightpaletteext0_1A0;
+  float weightpaletteext0_1A4;
+  float weightpaletteext0_1A8;
+  float weightpaletteext0_1AC;
+  float weightpaletteext0_1B0;
+  uint8_t gap1B4[11868];
+  GXTexObj texObjects_3010[248];
+  uint32_t field_4F10;
+  uint32_t field_4F14;
+  uint32_t primBuffPtr_4F18;
+  uint32_t primMaxCount_4F1C;
+  uint32_t field_4F20;
+  void* cameraCoreData_4F24;
+  void* cameraRoomData_4F28;
+  uint32_t field_4F2C;
+  void* ptr_field_4F30;
+  uint32_t field_4F34;
+  uint32_t field_4F38;
+  Vec field_4F3C;
+  uint32_t field_4F48;
+  uint8_t gap4F4C[32];
+  uint32_t field_4F6C;
+  uint32_t field_4F70;
+  Vec field_4F74;
+  uint8_t field_4F80;
+  uint8_t field_4F81;
+  uint16_t field_4F82;
+  uint32_t field_4F84;
+  uint32_t field_4F88;
+  uint32_t field_4F8C;
+  uint32_t field_globalSaveDataStartsHere_4F90;
+  int field_4F94;
+  uint8_t field_4F98;
+  uint8_t field_4F99;
+  uint8_t field_4F9A;
+  uint8_t field_4F9B;
+  uint16_t field_4F9C;
+  uint16_t field_4F9E;
+  uint16_t field_4FA0;
+  uint8_t field_4FA2;
+  uint8_t languageId_4FA3;
+  int field_4FA4;
+  int goldAmount_4FA8;
+  uint16_t curRoomId_4FAC;
+  uint8_t field_4FAE;
+  uint8_t field_4FAF;
+  uint16_t prevRoomId_4FB0;
+  uint8_t field_4FB2;
+  uint8_t field_4FB3;
+  int16_t field_4FB4;
+  uint16_t field_4FB6;
+  int16_t field_4FB8;
+  uint16_t field_4FBA;
+  uint32_t field_4FBC;
+  uint8_t field_4FC0;
+  uint8_t field_4FC1;
+  uint8_t field_4FC2;
+  uint8_t field_4FC3;
+  uint8_t field_4FC4;
+  uint8_t field_4FC5;
+  uint8_t field_4FC6;
+  uint8_t field_4FC7;
+  uint8_t curPlType_4FC8;
+  uint8_t field_4FC9;
+  uint8_t field_4FCA;
+  uint8_t field_4FCB;
+  uint16_t field_4FCC;
+  uint16_t field_4FCE;
+  float field_4FD0;
+  float field_4FD4;
+  float field_4FD8;
+  float field_4FDC;
+  uint32_t gap4FE0[15];
+  uint32_t flags_STATUS_501C[4];
+  uint8_t gap502C[12];
+  uint32_t flags_5038;
+  uint8_t gap503C[80];
+  uint32_t flags_508C;
+  uint8_t gap5090[28];
+  uint32_t flags_50AC;
+  uint8_t gap50B0[44];
+  uint32_t flags_50DC;
+  uint8_t gap50E0[428];
+  uint32_t flags_ITEM_SET_528C[1];
+  uint8_t gap5290[60];
+  uint32_t flags_SCENARIO_52CC[2];
+  uint32_t field_52D4;
+  uint32_t field_52D8;
+  uint32_t field_52DC;
+  uint32_t field_52E0;
+  uint32_t field_52E4;
+  uint32_t field_52E8;
+  uint32_t flags_KEY_LOCK_52EC[5];
+  uint8_t gap5300[12];
+  int field_530C;
+  uint32_t freeData_5310[64];
+  EM_LIST emList_5410[256];
+  uint8_t gap7410[4100];
+  uint8_t field_8414;
+  uint32_t field_8418[3];
+  uint32_t field_8424;
+  uint32_t field_8428;
+  uint8_t gap842C[40];
+  uint32_t field_8454;
+  uint32_t field_8458;
+  uint32_t field_845C;
+  uint16_t field_8460;
+  uint16_t field_8462;
+  uint32_t field_8464;
+  uint32_t field_8468;
+  uint32_t field_846C;
+  uint32_t field_8470;
+  uint32_t field_8474;
+  uint32_t field_8478;
+  uint8_t field_847C;
+  uint8_t field_847D;
+  uint8_t field_847E;
+  uint8_t field_847F;
+  uint32_t field_8480;
+  uint8_t gap8484[516];
+  uint8_t field_8688;
+  uint8_t field_8689;
+  uint32_t field_868C;
+
+  // seperate SystemSave struct follows - some things seem to access it via pG pointer though
+  // TODO: maybe just include SYSTEM_SAVE here - need to check if anything refers to GLOBALS size anywhere first
+  uint32_t flags_CONFIG_8690;
+  uint32_t flags_EXTRA_8694;
+  uint8_t languageId_8698;
+  uint8_t field_8699;
+  uint8_t field_869A;
+  uint8_t field_869B;
+  uint8_t soundMode_869C;
+  uint8_t adasReportNo_869D;
+};
+static_assert(sizeof(GLOBALS) == 0x86A0, "sizeof(GLOBALS)"); // TODO: find if this size is correct
+
+struct SYSTEM_SAVE
+{
+  uint32_t flags_CONFIG_0;
+  uint32_t flags_EXTRA_4;
+  uint8_t languageId_8;
+  uint8_t field_9;
+  uint8_t field_A;
+  uint8_t field_B;
+  uint8_t soundMode_C;
+  uint8_t adasReportNo_D;
+  uint8_t field_E;
+  uint8_t field_F;
+  uint32_t field_10;
+  uint32_t field_14;
+  uint32_t field_18;
+  uint32_t field_1C;
+  uint32_t field_20;
+  uint32_t field_24;
+  uint32_t field_28;
+  uint8_t struct_2C[80];
+  uint32_t field_7C;
+  uint32_t field_80;
+  uint32_t field_84;
+  uint32_t field_88;
+  uint32_t field_8C;
+  uint32_t field_90;
+  uint8_t gap94[12];
+};
+static_assert(sizeof(SYSTEM_SAVE) == 0xA0, "sizeof(SYSTEM_SAVE)"); // TODO: find if this size is correct
+
+#pragma pack(push, 1)
+struct cPlayer // unsure if correct name!
+{
+  /* 0x000 */ uint8_t unk0[0x94];
+  /* 0x094 */ float X;
+  /* 0x098 */ float Y;
+  /* 0x09C */ float Z;
+  /* 0x0A0 */ float unkA0;
+  /* 0x0A4 */ float Angle;
+  /* goes to 7F0+ */
+};
+#pragma pack(pop)
+static_assert(sizeof(cPlayer) == 0xA8, "sizeof(cPlayer)"); // TODO: nowhere near the correct size!
+
+std::string GameVersion();
+bool GameVersionIsDebug();
+
+GLOBALS* GlobalPtr();
+SYSTEM_SAVE* SystemSavePtr();
+cPlayer* PlayerPtr();
+
+bool Init_Game();

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -3,6 +3,7 @@
 #include "ToolMenu.h"
 #include "GameFlags.h"
 #include "dllmain.h"
+#include "Game.h"
 #include "ConsoleWnd.h"
 #include "Settings.h"
 #include "WndProcHook.h"
@@ -24,9 +25,6 @@ void(__cdecl* CardSave)(uint8_t a1, char a2);
 void(__cdecl* SubScreenOpen)(int a1, int a2);
 void(*FlagEdit_die)();
 
-uintptr_t pG_ptr;
-uintptr_t pSys_ptr;
-uintptr_t pPL_ptr; // cPlayer*
 uintptr_t* ptrtitleInitMovAddr;
 
 uint32_t* DbgFontColorArray = nullptr;
@@ -95,23 +93,9 @@ void eprintf_Hook(int a1, int a2, int a3, int a4, char* Format, ...)
 	eprintf_ScreenDisp(eprintf_buffer, float(a1), float(a2 + 64), DbgFontColorArray[a3]);
 }
 
-#pragma pack(push, 1)
-struct cPlayer // unsure if correct name!
-{
-	/* 0x000 */ uint8_t unk0[0x94];
-	/* 0x094 */ float X;
-	/* 0x098 */ float Y;
-	/* 0x09C */ float Z;
-	/* 0x0A0 */ float unkA0;
-	/* 0x0A4 */ float Angle;
-	/* goes to 7F0+ */
-};
-#pragma pack(pop)
-
 bool IsInDebugMenu()
 {
-	uint8_t* pG = *(uint8_t**)pG_ptr;
-	return (*(uint32_t*)(pG + 0x60) & GetFlagValue(uint32_t(Flags_DEBUG::DBG_TEST_MODE))) != 0;
+	return (GlobalPtr()->flags_DEBUG_60[0] & GetFlagValue(uint32_t(Flags_DEBUG::DBG_TEST_MODE))) != 0;
 }
 
 uint32_t Keyboard2Gamepad()
@@ -194,7 +178,7 @@ void __cdecl gameDebug_recreation(void* a1)
 
 		if (ShowInfoDisplay)
 		{
-			cPlayer* pPL = *(cPlayer**)pPL_ptr;
+			cPlayer* pPL = PlayerPtr();
 			if (pPL)
 				eprintf_Hook(32, 300, 0, 0, "[X %7.3f Y %7.3f Z %7.3f R %5.3f]", pPL->X, pPL->Y, pPL->Z, pPL->Angle);
 		}
@@ -206,10 +190,7 @@ void __cdecl gameDebug_recreation(void* a1)
 void(*MenuTask_Orig)();
 void MenuTask_Hook()
 {
-	uint8_t* pG = *(uint8_t**)pG_ptr;
-	uint32_t* pFlags_DEBUG = (uint32_t*)(pG + 0x60);
-
-	*pFlags_DEBUG |= GetFlagValue(uint32_t(Flags_DEBUG::DBG_TEST_MODE));
+	GlobalPtr()->flags_DEBUG_60[0] |= GetFlagValue(uint32_t(Flags_DEBUG::DBG_TEST_MODE));
 
 	MenuTask_Orig();
 }
@@ -271,11 +252,9 @@ void systemRestartInit_Hook()
 
 void ToolMenu_Exit()
 {
-	uint8_t* pG = *(uint8_t**)pG_ptr;
-
 	// Exit tool-menu state via FlagEdit_die
 	// FlagEdit_die overwrites pG+0x170 with contents of 0xC6D008, so we need to write that first...
-	*FlagEdit_Backup_pG = *(uint32_t*)(pG + 0x170);
+	*FlagEdit_Backup_pG = GlobalPtr()->flags_STOP_170;
 	FlagEdit_die();
 
 	// alternatively "TaskChain(MenuTask, 0);" should return us to tool-menu
@@ -284,16 +263,14 @@ void ToolMenu_Exit()
 
 void ToolMenu_GoldMax()
 {
-	uint8_t* pG = *(uint8_t**)pG_ptr;
-	*(uint32_t*)(pG + 0x4FA8) = 99999999;
+	GlobalPtr()->goldAmount_4FA8 = 99999999;
 
 	ToolMenu_Exit();
 }
 
 void ToolMenu_SecretOpen()
 {
-	uint8_t* pSys = *(uint8_t**)pSys_ptr;
-	uint32_t* flags_EXTRA = (uint32_t*)(pSys + 4);
+	uint32_t* flags_EXTRA = &SystemSavePtr()->flags_EXTRA_4;
 
 	// debug exe ORs these seperately, probably part of an enum or something
 	*flags_EXTRA |= GetFlagValue(uint32_t(Flags_EXTRA::CFG_AIM_REVERSE));
@@ -318,8 +295,7 @@ void ToolMenu_SecretOpen()
 
 void ToolMenu_MercenariesAllOpen()
 {
-	uint8_t* pSys = *(uint8_t**)pSys_ptr;
-	uint32_t* flags_EXTRA = (uint32_t*)(pSys + 4);
+	uint32_t* flags_EXTRA = &SystemSavePtr()->flags_EXTRA_4;
 
 	// TODO: confirm whether these are what this option actually unlocks in the debug build
 	// (as these unlocks seem kinda strange)
@@ -343,12 +319,7 @@ void ToolMenu_ToggleInfoDisp()
 const char* ToolMenu_ToggleHUDName = "TOGGLE HUD";
 void ToolMenu_ToggleHUD()
 {
-	uint8_t* pG = *(uint8_t**)pG_ptr;
-	uint32_t* flags_DISP = (uint32_t*)(pG + 0x58);
-
-	uint32_t offset = 0;
-	int value = GetFlagValue(uint32_t(Flags_DISP::DPF_COCKPIT), offset);
-	flags_DISP[offset / 4] ^= value;
+	GlobalPtr()->flags_DISP0_58 ^= GetFlagValue(uint32_t(Flags_DISP::DPF_COCKPIT));
 
 	ToolMenu_Exit();
 }
@@ -408,7 +379,6 @@ void GetToolMenuPointers()
 
 	pattern = hook::pattern("A1 ? ? ? ? B9 FF FF FF 7F 21 48 ? A1");
 	FlagEdit_die = (decltype(FlagEdit_die))pattern.count(1).get(0).get<uint8_t>(0);
-	pG_ptr = *(uintptr_t*)pattern.count(1).get(0).get<uint8_t>(1);
 	FlagEdit_Backup_pG = *(uint32_t**)pattern.count(1).get(0).get<uint8_t>(0x14);
 
 	pattern = hook::pattern("FF FF FF FF FF FF 00 00 FF 00");
@@ -426,16 +396,9 @@ void GetToolMenuPointers()
 	varPtr = pattern.count(1).get(0).get<uint32_t>(20);
 	roomInfoAddr = (uint32_t*)*varPtr;
 
-	pattern = hook::pattern("00 80 00 00 83 C4 ? E8 ? ? ? ? A1 ? ? ? ?");
-	varPtr = pattern.count(1).get(0).get<uint32_t>(13);
-	pSys_ptr = (uintptr_t)*varPtr;
-
 	pattern = hook::pattern("53 56 33 C0 BE ? ? ? ? 8D A4 24 00 00 00 00");
 	varPtr = pattern.count(1).get(0).get<uint32_t>(5);
 	ToolMenuEntries = (ToolMenuEntry*)*varPtr;
-
-	pattern = hook::pattern("A1 ? ? ? ? D8 CC D8 C9 D8 CA D9 5D ? D9 45 ?");
-	pPL_ptr = *pattern.count(1).get(0).get<uintptr_t>(1);
 
 	LightTool_GetPointers();
 }
@@ -573,7 +536,7 @@ void Init_ToolMenu()
 	}
 
 	// Allow RoomJump 1.1.0 to access stage 0 (test stages)
-	if (game_version == "1.1.0")
+	if (GameVersion() == "1.1.0")
 	{
 		pattern = hook::pattern("80 FB 05 7F ? 84 DB 7E ?");
 		injector::WriteMemory(pattern.count(1).get(0).get<uint8_t>(7), uint8_t(0x7C), true);

--- a/dllmain/ToolMenuLights.cpp
+++ b/dllmain/ToolMenuLights.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include "..\includes\stdafx.h"
-#include "GameFlags.h"
-
-extern uint8_t** ptrpG; // dllmain.cpp
+#include "Game.h"
 
 // tool_menu.cpp externs
 extern uint32_t* PadButtonStates;
@@ -176,13 +174,11 @@ void ToolMenu_LightToolMenu()
     int sizetest2 = sizeof(cLightMgr_EnvInfo);
 
     // Make sure game knows we're in a tool menu
-    uint8_t* Global = *ptrpG;
-    uint32_t* pFlags_DEBUG = (uint32_t*)(Global + 0x60);
-    uint32_t* pFlags_STOP = (uint32_t*)(Global + 0x170);
-    *pFlags_DEBUG |= GetFlagValue(uint32_t(Flags_DEBUG::DBG_TEST_MODE));
+    GLOBALS* Global = GlobalPtr();
+    Global->flags_DEBUG_60[0] |= GetFlagValue(uint32_t(Flags_DEBUG::DBG_TEST_MODE));
 
-    uint32_t Flags_STOP_Orig = *pFlags_STOP;
-    *pFlags_STOP |= ~GetFlagValue(uint32_t(Flags_STOP::SPF_CINESCO)); // stops all except cinesco?
+    uint32_t Flags_STOP_Orig = Global->flags_STOP_170;
+    Global->flags_STOP_170 |= ~GetFlagValue(uint32_t(Flags_STOP::SPF_CINESCO)); // stops all except cinesco?
 
     int SelectedIdx = 0;
     int PrevButtons = 0;
@@ -207,7 +203,7 @@ void ToolMenu_LightToolMenu()
         if (buttonStates & (uint32_t(GamePadButton::A) | uint32_t(GamePadButton::B)))
             if (SelectedIdx == NumMenuItems || (buttonStates & uint32_t(GamePadButton::B)))
             {
-                *pFlags_STOP = Flags_STOP_Orig;
+                Global->flags_STOP_170 = Flags_STOP_Orig;
                 ToolMenu_Return();
                 break;
             }

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -2,6 +2,7 @@
 #include <charconv>
 #include "..\includes\stdafx.h"
 #include "..\Wrappers\wrapper.h"
+#include "Game.h"
 #include "WndProcHook.h"
 #include "dllmain.h"
 #include "cfgMenu.h"
@@ -21,7 +22,6 @@
 std::string WrapperMode;
 std::string WrapperName;
 std::string rootPath;
-std::string game_version;
 
 HMODULE wrapper_dll = nullptr;
 HMODULE proxy_dll = nullptr;
@@ -42,7 +42,6 @@ uintptr_t ptrAfterItemExamineHook;
 uintptr_t ptrAfterEsp04TransHook;
 
 static uint32_t* ptrGameFrameRate;
-uint8_t** ptrpG;
 
 BOOL __stdcall SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int cx, int cy, UINT uFlags)
 {
@@ -92,34 +91,8 @@ void Init_Main()
 {
 	con.AddLogChar("Big ironic thanks to QLOC S.A.");
 
-	// Detect game version
-	auto pattern = hook::pattern("31 2E ? ? ? 00 00 00 6D 6F 76 69 65 2F 64 65 6D 6F 30 65 6E 67 2E 73 66 64");
-	int ver = injector::ReadMemory<int>(pattern.count(1).get(0).get<uint32_t>(2));
-
-	if (ver == 0x362E30) {
-		game_version = "1.0.6";
-	} else if (ver == 0x302E31) {
-		game_version = "1.1.0";
-	} else {
-		MessageBoxA(NULL, "This version of RE4 is not supported.\nre4_tweaks will be disabled.", "re4_tweaks", MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND);
+	if (!Init_Game())
 		return;
-	}
-
-	// Check for part of gameDebug function, if exists this must be a debug-enabled build
-	pattern = hook::pattern("6A 00 6A 00 6A 08 68 AE 01 00 00 6A 10 6A 0A");
-	if (pattern.size() > 0)
-	{
-		game_version += "d";
-		bisDebugBuild = true;
-	}
-
-	// Grab pointer to pG (pointer to games Global struct)
-	pattern = hook::pattern("A1 ? ? ? ? B9 FF FF FF 7F 21 48 ? A1");
-	ptrpG = *pattern.count(1).get(0).get<uint8_t**>(1);
-
-	#ifdef VERBOSE
-	con.AddConcatLog("Game version = ", game_version.data());
-	#endif
 
 	cfg.ReadSettings();
 
@@ -144,7 +117,7 @@ void Init_Main()
 	Init_ExceptionHandler();
 
 	// Remove savegame SteamID checks, allows easier save transfers
-	pattern = hook::pattern("8B 88 40 1E 00 00 3B 4D ? 0F 85 ? ? ? ?");
+	auto pattern = hook::pattern("8B 88 40 1E 00 00 3B 4D ? 0F 85 ? ? ? ?");
 	Nop(pattern.count(1).get(0).get<uint8_t>(0x9), 6);
 	Nop(pattern.count(1).get(0).get<uint8_t>(0x18), 6);
 

--- a/dllmain/dllmain.h
+++ b/dllmain/dllmain.h
@@ -10,4 +10,3 @@ extern bool bisDebugBuild;
 
 extern std::string WrapperName;
 extern std::string rootPath;
-extern std::string game_version;

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="ControllerTweaks.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="ExceptionHandler.cpp" />
+    <ClCompile Include="Game.cpp" />
     <ClCompile Include="KeyboardMouseTweaks.cpp" />
     <ClCompile Include="LAApatch.cpp" />
     <ClCompile Include="MouseTurning.cpp" />
@@ -176,6 +177,7 @@
     <ClInclude Include="ControllerTweaks.h" />
     <ClInclude Include="ExceptionHandler.h" />
     <ClInclude Include="FilterXXFixes.h" />
+    <ClInclude Include="Game.h" />
     <ClInclude Include="GameFlags.h" />
     <ClInclude Include="dllmain.h" />
     <ClInclude Include="cfgMenu.h" />

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -88,11 +88,14 @@
     <ClCompile Include="ExceptionHandler.cpp">
       <Filter>dllmain</Filter>
     </ClCompile>
+    <ClCompile Include="..\external\imgui\imgui_stdlib.cpp">
+      <Filter>includes\external\ImGui</Filter>
+    </ClCompile>
     <ClCompile Include="ControllerTweaks.cpp">
       <Filter>dllmain</Filter>
     </ClCompile>
-    <ClCompile Include="..\external\imgui\imgui_stdlib.cpp">
-      <Filter>includes\external\ImGui</Filter>
+    <ClCompile Include="Game.cpp">
+      <Filter>dllmain</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -312,11 +315,14 @@
     <ClInclude Include="..\Wrappers\x3daudio1_7.h">
       <Filter>Wrappers</Filter>
     </ClInclude>
+    <ClInclude Include="..\external\imgui\imgui_stdlib.h">
+      <Filter>includes\external\ImGui</Filter>
+    </ClInclude>
     <ClInclude Include="ControllerTweaks.h">
       <Filter>dllmain</Filter>
     </ClInclude>
-    <ClInclude Include="..\external\imgui\imgui_stdlib.h">
-      <Filter>includes\external\ImGui</Filter>
+    <ClInclude Include="Game.h">
+      <Filter>dllmain</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Moved some of the more common pointers & game-related structs to a Game.h header, and made them accessible through getter-only `GlobalPtr()` `PlayerPtr()` etc funcs.

Also added structs like `GLOBALS` etc from my IDB here, so we can access the fields normally instead of needing to use ugly pointer offsets, these structs are really barebones atm, but lets us get rid of most of those pointer accesses at least.

(just hope those structs all match between different game versions, seems like most things get stored at the same offset at least, so don't think they'd differ _too_ much)

If you think anything else should be moved there too let me know, wasn't really sure how much to put in there.