### PR TITLE
SilenceArmoredAshley: fix for pattern not matching 1.1.0 properly, fixes #131

### DIFF
--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -151,7 +151,7 @@ void __cdecl gameDebug_recreation(void* a1)
 			PadButtonStates[4] = PadButtonStates[3] = PadButtonStates[1] = PadButtonStates[0] = 0;
 	}
 
-	if (!bisDebugBuild)
+	if (!GameVersionIsDebug())
 	{
 		// Check for LT + LS buttons
 		// (make sure they're the only ones pressed - if player opens a UI at same time it'll likely cause a hang...)
@@ -432,7 +432,7 @@ void Init_ToolMenu()
 	pattern = hook::pattern("52 68 ? ? ? ? E8 ? ? ? ? 83 C4 ? 5D");
 	injector::WriteMemory(pattern.count(1).get(0).get<uint32_t>(2), &MenuTask_Hook, true);
 
-	if (bisDebugBuild)
+	if (GameVersionIsDebug())
 	{
 		// hook gameDebug so we can use the gamepad emulation stuff to add keyboard support
 		pattern = hook::pattern("EB 03 8D 49 00 E8 ? ? ? ? 53 E8 ? ? ? ?");
@@ -543,7 +543,7 @@ void Init_ToolMenu()
 	}
 
 	// Overwrite non-functional tool menu entries with replacements
-	if (!bisDebugBuild)
+	if (!GameVersionIsDebug())
 	{
 		ToolMenuEntries[1].FuncPtr = &ToolMenu_GoldMax;
 		ToolMenuEntries[15].FuncPtr = &ToolMenu_SecretOpen;
@@ -570,7 +570,7 @@ void Init_ToolMenu()
 		ToolMenuEntries[12].FuncPtr = &ToolMenu_ToggleInfoDisp;
 
 		// Clear non-functional options on non-debug builds
-		if (!bisDebugBuild)
+		if (!GameVersionIsDebug())
 		{
 			for (int i = 0; i < 32; i++)
 			{

--- a/dllmain/ToolMenuDebug.cpp
+++ b/dllmain/ToolMenuDebug.cpp
@@ -1,13 +1,12 @@
 #include <iostream>
 #include "..\includes\stdafx.h"
 #include "ToolMenu.h"
-#include "GameFlags.h"
+#include "Game.h"
 #include "ConsoleWnd.h"
 
 // Fixes for debug-builds tool menu
 // (mainly just hooks for funcs that handle input for those menus, so we can slow down inputs to them)
 
-extern bool bisDebugBuild; // dllmain.cpp
 extern uint32_t* PadButtonStates; // tool_menu.cpp
 uint32_t Keyboard2Gamepad(); // tool_menu.cpp
 
@@ -147,7 +146,7 @@ void Init_ToolMenuDebug()
     injector::WriteMemory(&roomJump_funcs[1], &roomJumpMove_Hook, true);
 
     // tp funcs
-    if (bisDebugBuild)
+    if (GameVersionIsDebug())
     {
         pattern = hook::pattern("A1 ? ? ? ? C6 80 EA 04 00 00 00 C3");
         ToolOptionClass_ptr = *pattern.count(1).get(0).get<uint32_t*>(1);

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -30,7 +30,6 @@ bool bCfgMenuOpen;
 bool bConsoleOpen;
 bool bShouldFlipX;
 bool bShouldFlipY;
-bool bisDebugBuild;
 
 int g_UserRefreshRate;
 

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -257,8 +257,8 @@ void Init_Main()
 	// Silence armored Ashley
 	if (cfg.bSilenceArmoredAshley)
 	{
-		auto pattern = hook::pattern("75 ? 83 FF ? 77 ? 0F B6 87 ? ? ? ? FF 24 85");
-		injector::WriteMemory(pattern.count(1).get(0).get<uint32_t>(0), (uint8_t)0xEB, true); // jne -> jmp
+		auto pattern = hook::pattern("CB 4F 00 00 02 75 ? 83 FF ? 77 ? 0F B6 87 ? ? ? ? FF 24 85");
+		injector::WriteMemory(pattern.count(1).get(0).get<uint32_t>(5), (uint8_t)0xEB, true); // jne -> jmp
 	}
 
 	// Apply window changes

--- a/dllmain/dllmain.h
+++ b/dllmain/dllmain.h
@@ -6,7 +6,6 @@ extern bool bCfgMenuOpen;
 extern bool bConsoleOpen;
 extern bool bShouldFlipX;
 extern bool bShouldFlipY;
-extern bool bisDebugBuild;
 
 extern std::string WrapperName;
 extern std::string rootPath;


### PR DESCRIPTION
Seems to be working across all 3 versions now.

I noticed 1.0.6debug would crash if `EnableDebugMenu` was set to true though - looks like I forgot to update some things to use `GameVersionIsDebug()` instead, oops..

With those updated it should work fine now.