### PR TITLE
UseSprintToggle: allows toggling sprint instead of needing to hold it, fixes #130

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -327,6 +327,7 @@ void Settings::ReadSettings()
 	cfg.bFixRetryLoadMouseSelector = iniReader.ReadBoolean("MOUSE", "FixRetryLoadMouseSelector", true);
 
 	// KEYBOARD
+	cfg.bUseSprintToggle = iniReader.ReadBoolean("KEYBOARD", "UseSprintToggle", false);
 	cfg.bFallbackToEnglishKeyIcons = iniReader.ReadBoolean("KEYBOARD", "FallbackToEnglishKeyIcons", true);
 	cfg.sFlipItemUp = iniReader.ReadString("KEYBOARD", "FlipItemUp", "HOME");
 	cfg.sFlipItemDown = iniReader.ReadString("KEYBOARD", "FlipItemDown", "END");
@@ -460,6 +461,7 @@ void Settings::WriteSettings()
 	iniReader.WriteBoolean("MOUSE", "FixRetryLoadMouseSelector", cfg.bFixRetryLoadMouseSelector);
 
 	// KEYBOARD
+	iniReader.WriteBoolean("KEYBOARD", "UseSprintToggle", cfg.bUseSprintToggle);
 	iniReader.WriteBoolean("KEYBOARD", "FallbackToEnglishKeyIcons", cfg.bFallbackToEnglishKeyIcons);
 	iniReader.WriteString("KEYBOARD", "FlipItemUp", " " + cfg.sFlipItemUp);
 	iniReader.WriteString("KEYBOARD", "FlipItemDown", " " + cfg.sFlipItemDown);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -39,6 +39,7 @@ struct Settings
 	float fTurnSensitivity;
 	bool bUseRawMouseInput;
 	bool bUnlockCameraFromAim;
+	bool bUseSprintToggle;
 	bool bFallbackToEnglishKeyIcons;
 	bool bFixSniperZoom;
 	bool bFixSniperFocus;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -546,8 +546,19 @@ void cfgMenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("UseSprintToggle", &cfg.bUseSprintToggle);
+				ImGui::TextWrapped("Changes sprint key to act like a toggle instead of needing to be held.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// English key icons
-				cfg.HasUnsavedChanges |= ImGui::Checkbox("FallbackToEnglishKeyIcons", &cfg.bFallbackToEnglishKeyIcons);
+				if (ImGui::Checkbox("FallbackToEnglishKeyIcons", &cfg.bFallbackToEnglishKeyIcons))
+				{
+					cfg.HasUnsavedChanges = true;
+					NeedsToRestart = true;
+				}
 				ImGui::TextWrapped("Game will turn keys invisible for certain unsupported keyboard languages, enabling this should make game use English keys for unsupported ones instead (requires game restart)");
 			}
 

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -132,6 +132,9 @@ FlipItemRight = PAGEUP
 QTE_key_1 = D
 QTE_key_2 = A
 
+; Changes sprint key to act like a toggle instead of needing to be held.
+UseSprintToggle = false
+
 ; Game will turn keys invisible for certain unsupported keyboard languages
 ; Enabling this should make game use English keys for unsupported ones instead
 ; (if game supports your current language it should still use it however)


### PR DESCRIPTION
Allows sprint to stay toggled until the FORWARD key is released, the toggle can be enabled/disabled during runtime at will.

It might be nice if this could be extended so that pressing sprint key again could untoggle it, but guess that might need some extra code to track when KEY_RUN was released & then pressed again (or maybe not, maybe `Key.buttonsTriggered_20` / `Key.buttonsReleased_28` could be made use of instead, not sure)

I think this might also affect controller too but haven't tried it myself, if it works fine there I guess maybe should move it to a different category instead.

Thanks to nipkownix for actually getting the hook to work too, seems I need to brush up on ASM some more...

Tested with 1.1.0/1.0.6/1.0.6debug, seems to work fine across them all.

(btw if anyone used the hex patches in #130, make sure to undo them before using this, since it relies on searching for the original bytes there)