### PR TITLE
FixTurningSpeed: makes backwards turn speed consistent between framerates

### DIFF
--- a/dllmain/LoggingInit.cpp
+++ b/dllmain/LoggingInit.cpp
@@ -104,6 +104,17 @@ void LogSettings()
 
 	Logging::Log() << "+--------------------------------+-----------------+";
 
+	// KEYBOARD
+	Logging::Log() << "+ KEYBOARD-----------------------+-----------------+";
+
+	sprintf(settingBuf, "| %-30s | %15s |", "UseSprintToggle", cfg.bUseSprintToggle ? "true" : "false");
+	Logging::Log() << settingBuf;
+
+	sprintf(settingBuf, "| %-30s | %15s |", "FallbackToEnglishKeyIcons", cfg.bFallbackToEnglishKeyIcons ? "true" : "false");
+	Logging::Log() << settingBuf;
+
+	Logging::Log() << "+--------------------------------+-----------------+";
+
 	// MOUSE
 	Logging::Log() << "+ MOUSE--------------------------+-----------------+";
 
@@ -134,6 +145,9 @@ void LogSettings()
 	Logging::Log() << "+ FRAME RATE---------------------+-----------------+";
 
 	sprintf(settingBuf, "| %-30s | %15s |", "FixFallingItemsSpeed", cfg.bFixFallingItemsSpeed ? "true" : "false");
+	Logging::Log() << settingBuf;
+
+	sprintf(settingBuf, "| %-30s | %15s |", "FixTurningSpeed", cfg.bFixTurningSpeed ? "true" : "false");
 	Logging::Log() << settingBuf;
 
 	sprintf(settingBuf, "| %-30s | %15s |", "FixQTE", cfg.bFixQTE ? "true" : "false");

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -329,6 +329,7 @@ void Settings::ReadSettings()
 
 	// FRAME RATE
 	cfg.bFixFallingItemsSpeed = iniReader.ReadBoolean("FRAME RATE", "FixFallingItemsSpeed", true);
+	cfg.bFixTurningSpeed = iniReader.ReadBoolean("FRAME RATE", "FixTurningSpeed", true);
 	cfg.bFixQTE = iniReader.ReadBoolean("FRAME RATE", "FixQTE", true);
 	cfg.bFixAshleyBustPhysics = iniReader.ReadBoolean("FRAME RATE", "FixAshleyBustPhysics", true);
 
@@ -464,6 +465,7 @@ void Settings::WriteSettings()
 
 	// FRAME RATE
 	iniReader.WriteBoolean("FRAME RATE", "FixFallingItemsSpeed", cfg.bFixFallingItemsSpeed);
+	iniReader.WriteBoolean("FRAME RATE", "FixTurningSpeed", cfg.bFixTurningSpeed);
 	iniReader.WriteBoolean("FRAME RATE", "FixQTE", cfg.bFixQTE);
 	iniReader.WriteBoolean("FRAME RATE", "FixAshleyBustPhysics", cfg.bFixAshleyBustPhysics);
 

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -49,6 +49,7 @@ struct Settings
 
 	// FRAME RATE
 	bool bFixFallingItemsSpeed;
+	bool bFixTurningSpeed;
 	bool bFixQTE;
 	bool bFixAshleyBustPhysics;
 

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -498,6 +498,14 @@ void cfgMenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				// FixTurningSpeed
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("FixTurningSpeed", &cfg.bFixTurningSpeed);
+				ImGui::TextWrapped("Fixes speed of backwards turning when using framerates other than 30FPS.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// FixQTE
 				cfg.HasUnsavedChanges |= ImGui::Checkbox("FixQTE", &cfg.bFixQTE);
 				ImGui::TextWrapped("When running in 60 FPS, some QTEs require extremely fast button presses to work. This gets even worse in Professional difficulty, making it seem almost impossible to survive the minecart and the statue bridge QTEs.");

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -115,6 +115,9 @@ ControllerSensitivity = 1.0
 ; Fixes the speed of falling items in 60 FPS, making them not fall at double speed.
 FixFallingItemsSpeed = true
 
+; Fixes speed of backwards turning when using framerates other than 30FPS.
+FixTurningSpeed = true
+
 ; When running in 60 FPS, some QTEs require extremely fast button presses to work. This gets even worse in Professional difficulty,
 ; making it seem almost impossible to survive the minecart and the statue bridge QTEs.
 ; This fix makes QTEs that involve rapid button presses much more forgiving.


### PR DESCRIPTION
This is mostly useful with high framerates (where backward turning happens almost instantly), but it does slightly improve 60FPS too, making it match up with the 30FPS speed - also seems like the camera angle when turning gets improved by it a little bit as well.

(kinda silly that they didn't include this themselves, they did update pl_R1_Walk/pl_R1_Run to make use of deltaTime, but didn't bother with anything else...)

This also patches `pl_R1_KlauserAttack` since that also made use of the same `cPlayer::SPEED_WALK_TURN` var, but not really sure how to test that out yet, if anyone can try it out would appreciate it!

Tested with 1.1.0/1.0.6/1.0.6dbg, you can see the difference pretty easily by toggling it in cfgMenu while turning backwards.