### PR TITLE
Add issue templates for bugs & features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,30 @@
+name: Bug report
+description: Let us know about bugs found with the game / tweaks
+labels: bug
+body:
+  - id: disclaimer
+    type: markdown
+    attributes:
+      value: |
+        This is the issues page for re4_tweaks, if your issue is related to the RE4 HD Project (eg. texture/modelling problem) please post to the [re4hd.com website](https://www.re4hd.com) instead - your comment is much more likely to be noticed by Albert or Cris there.
+        
+        Though feel free to post any crashing/performance/other bugs in the game here, but please follow the validation checklist below.
+        
+        **If your issue is crashing related**: please try creating a `CrashDumps` folder next to your bio4.exe file, and try getting the crash to happen again - after that you should hopefully have a ZIP file inside the CrashDumps folder, please attach that ZIP with your post!
+
+        If you can, make sure to mention your game version in the report (should be displayed on bottom right of main menu), and also if you use a non-English OS language (or non-Windows OS)
+  - id: validation
+    type: checkboxes
+    attributes:
+      label: Validation
+      options:
+      - label: "Game has been updated to the latest RE4HD release (v1.0.1: https://www.re4hd.com/?p=9471)"
+        required: true
+      - label: "Data has been [validated with SFV](https://www.re4hd.com/?p=9454) (a guide to using QuickSFV is available at that link, use that with this 1.0.1 SFV: [BIO4-HDProject1.0.1-SFV.zip](https://github.com/nipkownix/re4_tweaks/files/8057899/BIO4-HDProject1.0.1-SFV.zip))"
+        required: true
+  - id: problem
+    type: textarea
+    attributes:
+      label: Describe your issue here (drag+drop ZIP to attach it)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest a tweak/fix/feature to add to the game
+labels: feature
+body:
+  - id: disclaimer
+    type: markdown
+    attributes:
+      value: |
+        Please feel free to suggest any tweak/fix/feature you'd like to see added to the game!
+        
+        We'd appreciate it if you could [search through the existing issues](https://github.com/nipkownix/re4_tweaks/issues) to see if something similar has already been suggested first.
+        (replying to existing issues would also help us know which ones should be prioritized)
+  - id: feature
+    type: textarea
+    attributes:
+      label: Describe the feature you'd like to see added
+    validations:
+      required: true


### PR DESCRIPTION
Adds the templates from https://github.com/emoose/re4_tweaks/issues/new/choose

I think merging it should be enough for github to pick it up, but if not you might need to go into Settings page -> scroll down to Issues section -> `Set up templates`, and see if something has to be enabled there.

Of course feel free to edit the branch if you want to change anything.