### PR TITLE
ViolenceLevelOverride: allows overriding level of violence in the game

### DIFF
--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -349,7 +349,7 @@ struct SYSTEM_SAVE
   uint32_t flags_CONFIG_0;
   uint32_t flags_EXTRA_4;
   uint8_t languageId_8;
-  uint8_t field_9;
+  uint8_t violenceLevel_9;
   uint8_t field_A;
   uint8_t field_B;
   uint8_t soundMode_C;

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -345,6 +345,7 @@ void Settings::ReadSettings()
 	// MISC
 	cfg.sWrappedDllPath = iniReader.ReadString("MISC", "WrappedDLLPath", "");
 	cfg.bAshleyJPCameraAngles = iniReader.ReadBoolean("MISC", "AshleyJPCameraAngles", false);
+	cfg.iViolenceLevelOverride = iniReader.ReadInteger("MISC", "ViolenceLevelOverride", -1);
 	cfg.bAllowSellingHandgunSilencer = iniReader.ReadBoolean("MISC", "AllowSellingHandgunSilencer", true);
 	cfg.bAllowMafiaLeonCutscenes = iniReader.ReadBoolean("MISC", "AllowMafiaLeonCutscenes", true);
 	cfg.bSilenceArmoredAshley = iniReader.ReadBoolean("MISC", "SilenceArmoredAshley", false);
@@ -484,6 +485,7 @@ void Settings::WriteSettings()
 
 	// MISC
 	iniReader.WriteBoolean("MISC", "AshleyJPCameraAngles", cfg.bAshleyJPCameraAngles);
+	iniReader.WriteInteger("MISC", "ViolenceLevelOverride", cfg.iViolenceLevelOverride);
 	iniReader.WriteBoolean("MISC", "AllowSellingHandgunSilencer", cfg.bAllowSellingHandgunSilencer);
 	iniReader.WriteBoolean("MISC", "AllowMafiaLeonCutscenes", cfg.bAllowMafiaLeonCutscenes);
 	iniReader.WriteBoolean("MISC", "SilenceArmoredAshley", cfg.bSilenceArmoredAshley);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -58,6 +58,7 @@ struct Settings
 	// MISC
 	std::string sWrappedDllPath;
 	bool bAshleyJPCameraAngles;
+	int iViolenceLevelOverride;
 	bool bAllowSellingHandgunSilencer;
 	bool bAllowMafiaLeonCutscenes;
 	bool bSilenceArmoredAshley;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -571,6 +571,21 @@ void cfgMenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				// ViolenceLevelOverride
+				ImGui::PushItemWidth(150);
+				if (ImGui::InputInt("Violence Level Override", &cfg.iViolenceLevelOverride))
+				{
+					cfg.HasUnsavedChanges = true;
+					NeedsToRestart = true; // unfortunately required as game only reads pSys from savegame during first loading screen...
+				}
+				ImGui::PopItemWidth();
+				ImGui::TextWrapped("Allows overriding the level of violence in the game.");
+				ImGui::TextWrapped("Use -1 to leave as games default, 0 for low-violence mode (as used in JP/GER version), or 2 for full violence.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// AllowSellingHandgunSilencer
 				if (ImGui::Checkbox("AllowSellingHandgunSilencer", &cfg.bAllowSellingHandgunSilencer))
 				{

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -142,6 +142,10 @@ FixAshleyBustPhysics = true
 ; Unlocks the JP-only classic camera angles during Ashley's segment.
 AshleyJPCameraAngles = false
 
+; Allows overriding the level of violence in the game.
+; Use -1 to leave as your game EXEs default, 0 for low-violence mode (as used in JP/GER version), or 2 for full violence.
+ViolenceLevelOverride = -1
+
 ; Allows selling the (normally unused) handgun silencer to the merchant.
 ; If you use a mod that changes the merchant price tables you might want to disable this
 ; But if you're only using RE4HD you can leave this enabled


### PR DESCRIPTION
Some builds like JP/GER have low-violence-only EXEs, this should allow those to have full violence enabled instead, similarly full-violence EXEs should now be able to act like low-violence ones too.

More details in #153

Tested across 1.0.6/1.0.6jpn/1.0.6dbg/1.1.0, seems to be updating the pSys->field_9 field fine, haven't been able to test with German release yet though since I don't have the EXE for it atm.

I'm not totally sure if all the violence censorship is removed in JP/GER however since I'm not that familiar with those versions.

**If someone with those versions wants to try testing**, here's a build of this PR with violence set to full: [re4_tweaks-violenceLevelOverride.zip](https://github.com/nipkownix/re4_tweaks/files/8330405/re4_tweaks-violenceLevelOverride.zip)
 
E: ah, I've been told German copy is now uncensored, so guess we don't need to worry about testing with that - it'd still be interesting to get a look at the old censored release though, if any German owners know how to use DepotDownloader, the depot for that is at https://steamdb.info/depot/254702/ - looks like it should still be accessible to German owners.