### PR TITLE
JetSkiTricks: patch gamepad-only code to allow mouse/keyboard combos

### DIFF
--- a/dllmain/LoggingInit.cpp
+++ b/dllmain/LoggingInit.cpp
@@ -165,6 +165,9 @@ void LogSettings()
 	sprintf(settingBuf, "| %-30s | %15s |", "AshleyJPCameraAngles", cfg.bAshleyJPCameraAngles ? "true" : "false");
 	Logging::Log() << settingBuf;
 
+	sprintf(settingBuf, "| %-30s | %15d |", "ViolenceLevelOverride", cfg.iViolenceLevelOverride);
+	Logging::Log() << settingBuf;
+
 	sprintf(settingBuf, "| %-30s | %15s |", "AllowSellingHandgunSilencer", cfg.bAllowSellingHandgunSilencer ? "true" : "false");
 	Logging::Log() << settingBuf;
 

--- a/dllmain/LoggingInit.cpp
+++ b/dllmain/LoggingInit.cpp
@@ -220,6 +220,9 @@ void LogSettings()
 	sprintf(settingBuf, "| %-30s | %15s |", "MouseTurningModifier", cfg.sMouseTurnModifierKeyCombo.data());
 	Logging::Log() << settingBuf;
 
+	sprintf(settingBuf, "| %-30s | %15s |", "JetSkiTricks", cfg.sJetSkiTrickCombo.data());
+	Logging::Log() << settingBuf;
+
 	Logging::Log() << "+--------------------------------+-----------------+";
 
 	// FPS WARNING

--- a/dllmain/Patches.h
+++ b/dllmain/Patches.h
@@ -27,6 +27,7 @@ bool ParseConsoleKeyCombo(std::string_view in_combo);
 bool ParseConfigMenuKeyCombo(std::string_view in_combo);
 bool ParseMouseTurnModifierCombo(std::string_view in_combo);
 bool ParseToolMenuKeyCombo(std::string_view in_combo);
+bool ParseJetSkiTrickCombo(std::string_view in_combo);
 
 // Deadzone pointers
 extern int* g_XInputDeadzone_LS;

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -381,6 +381,10 @@ void Settings::ReadSettings()
 	if (cfg.sMouseTurnModifierKeyCombo.length())
 		ParseMouseTurnModifierCombo(cfg.sMouseTurnModifierKeyCombo);
 
+	cfg.sJetSkiTrickCombo = iniReader.ReadString("HOTKEYS", "JetSkiTricks", "LMOUSE+RMOUSE");
+	if (cfg.sJetSkiTrickCombo.length())
+		ParseJetSkiTrickCombo(cfg.sJetSkiTrickCombo);
+
 	// FPS WARNING
 	cfg.bIgnoreFPSWarning = iniReader.ReadBoolean("WARNING", "IgnoreFPSWarning", false);
 	
@@ -504,6 +508,7 @@ void Settings::WriteSettings()
 	iniReader.WriteString("HOTKEYS", "Console", " " + cfg.sConsoleKeyCombo);
 	iniReader.WriteString("HOTKEYS", "DebugMenu", " " + cfg.sDebugMenuKeyCombo);
 	iniReader.WriteString("HOTKEYS", "MouseTurningModifier", " " + cfg.sMouseTurnModifierKeyCombo);
+	iniReader.WriteString("HOTKEYS", "JetSkiTricks", " " + cfg.sJetSkiTrickCombo);
 
 	// IMGUI
 	iniReader.WriteFloat("IMGUI", "FontSize", cfg.fFontSize);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -77,6 +77,7 @@ struct Settings
 	std::string sConsoleKeyCombo;
 	std::string sDebugMenuKeyCombo;
 	std::string sMouseTurnModifierKeyCombo;
+	std::string sJetSkiTrickCombo;
 
 	// WARNING
 	bool bIgnoreFPSWarning;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -123,6 +123,7 @@ void cfgMenuRender()
 				ParseToolMenuKeyCombo(cfg.sDebugMenuKeyCombo);
 				ParseConfigMenuKeyCombo(cfg.sConfigMenuKeyCombo);
 				ParseMouseTurnModifierCombo(cfg.sMouseTurnModifierKeyCombo);
+				ParseJetSkiTrickCombo(cfg.sJetSkiTrickCombo);
 
 				// Update console title
 				con.TitleKeyCombo = cfg.sConsoleKeyCombo;
@@ -768,6 +769,20 @@ void cfgMenuRender()
 
 				ImGui::PushItemWidth(100);
 				ImGui::InputText("MouseTurning modifier", &cfg.sMouseTurnModifierKeyCombo, ImGuiInputTextFlags_CharsUppercase);
+				ImGui::PopItemWidth();
+
+				if (ImGui::IsItemEdited())
+					cfg.HasUnsavedChanges = true;
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
+				// JetSkiTricks bindings
+				ImGui::TextWrapped("Key combo for jump tricks during Jet-ski sequence (normally RT+LT on controller)");
+
+				ImGui::PushItemWidth(100);
+				ImGui::InputText("Trick while riding Jet-ski", &cfg.sJetSkiTrickCombo, ImGuiInputTextFlags_CharsUppercase);
 				ImGui::PopItemWidth();
 
 				if (ImGui::IsItemEdited())

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -203,6 +203,9 @@ DebugMenu = CTRL+F3
 ; MouseTurning camera modifier. When holding this key combination, MouseTurning is temporarily activated/deactivated.
 MouseTurningModifier = ALT
 
+; Key combo for jump tricks during Jet-ski sequence (normally RT+LT on controller)
+JetSkiTricks = LMOUSE+RMOUSE
+
 [WARNING]
 ; This version of RE4 only works properly if played at 30 or 60 FPS. Anything else can and will cause numerous amounts of
 ; different bugs, most of which aren't even documented. By default, re4_tweaks will warn you about these issues and change


### PR DESCRIPTION
Hey hope all is well, here's a PR for the jet-ski patches mentioned in https://github.com/nipkownix/re4_tweaks/issues/158#issuecomment-1088311559

This just hooks `pl0e_R1_Jump` so we can check for a keyboard/mouse combo before the controller checks, the way I patch around the checks here is a little hacky, as they check for both RT & LT with two seperate test/jz instructions, seemed easier to make the hook return past those tests & skip them if combo pressed instead of needing to hook them both individually, maybe there's a better way to handle that though.

Tested with 1.1.0/1.0.6/1.0.6dbg so far, not sure about other releases, as long as those RT/LT tests are always 0x28 bytes it should be fine, hopefully none of the other versions changed that at all.

Here's a build of these commits, has some very minor improvements from the earlier build:
[dinput8-jetSkiTricks-v2.zip](https://github.com/nipkownix/re4_tweaks/files/8441378/dinput8-jetSkiTricks-v2.zip)
