### PR TITLE
AllowAshleySuplex: allows Ashley to suplex in very specific situations

### DIFF
--- a/dllmain/LoggingInit.cpp
+++ b/dllmain/LoggingInit.cpp
@@ -177,6 +177,9 @@ void LogSettings()
 	sprintf(settingBuf, "| %-30s | %15s |", "SilenceArmoredAshley", cfg.bSilenceArmoredAshley ? "true" : "false");
 	Logging::Log() << settingBuf;
 
+	sprintf(settingBuf, "| %-30s | %15s |", "AllowAshleySuplex", cfg.bAllowAshleySuplex ? "true" : "false");
+	Logging::Log() << settingBuf;
+
 	sprintf(settingBuf, "| %-30s | %15s |", "DisableQTE", cfg.bDisableQTE ? "true" : "false");
 	Logging::Log() << settingBuf;
 	

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -356,6 +356,7 @@ void Settings::ReadSettings()
 	cfg.bAllowSellingHandgunSilencer = iniReader.ReadBoolean("MISC", "AllowSellingHandgunSilencer", true);
 	cfg.bAllowMafiaLeonCutscenes = iniReader.ReadBoolean("MISC", "AllowMafiaLeonCutscenes", true);
 	cfg.bSilenceArmoredAshley = iniReader.ReadBoolean("MISC", "SilenceArmoredAshley", false);
+	cfg.bAllowAshleySuplex = iniReader.ReadBoolean("MISC", "AllowAshleySuplex", false);
 	cfg.bDisableQTE = iniReader.ReadBoolean("MISC", "DisableQTE", false);
 	cfg.bAutomaticMashingQTE = iniReader.ReadBoolean("MISC", "AutomaticMashingQTE", false);
 	cfg.bSkipIntroLogos = iniReader.ReadBoolean("MISC", "SkipIntroLogos", false);
@@ -500,6 +501,7 @@ void Settings::WriteSettings()
 	iniReader.WriteBoolean("MISC", "AllowSellingHandgunSilencer", cfg.bAllowSellingHandgunSilencer);
 	iniReader.WriteBoolean("MISC", "AllowMafiaLeonCutscenes", cfg.bAllowMafiaLeonCutscenes);
 	iniReader.WriteBoolean("MISC", "SilenceArmoredAshley", cfg.bSilenceArmoredAshley);
+	iniReader.WriteBoolean("MISC", "AllowAshleySuplex", cfg.bAllowAshleySuplex);
 	iniReader.WriteBoolean("MISC", "DisableQTE", cfg.bDisableQTE);
 	iniReader.WriteBoolean("MISC", "AutomaticMashingQTE", cfg.bAutomaticMashingQTE);
 	iniReader.WriteBoolean("MISC", "SkipIntroLogos", cfg.bSkipIntroLogos);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -62,6 +62,7 @@ struct Settings
 	bool bAllowSellingHandgunSilencer;
 	bool bAllowMafiaLeonCutscenes;
 	bool bSilenceArmoredAshley;
+	bool bAllowAshleySuplex;
 	bool bDisableQTE;
 	bool bAutomaticMashingQTE;
 	bool bSkipIntroLogos;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -630,6 +630,15 @@ void cfgMenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				// AllowAshleySuplex
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("AllowAshleySuplex", &cfg.bAllowAshleySuplex);
+				ImGui::TextWrapped("Allows Ashley to Suplex enemies in very specific situations.");
+				ImGui::TextWrapped("(previously was only possible in the initial NTSC GameCube ver., was patched out in all later ports.)");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// UseSprintToggle
 				cfg.HasUnsavedChanges |= ImGui::Checkbox("UseSprintToggle", &cfg.bUseSprintToggle);
 				ImGui::TextWrapped("Changes sprint key to act like a toggle instead of needing to be held.");

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -158,6 +158,10 @@ AllowMafiaLeonCutscenes = true
 ; For those who also hate the constant "Clank Clank Clank".
 SilenceArmoredAshley = false
 
+; Allows Ashley to Suplex enemies in very specific situations.
+; (previously was only possible in the initial NTSC GameCube ver., was patched out in all later ports.)
+AllowAshleySuplex = false
+
 ; Disables most of the QTEs, making them pass automatically.
 DisableQTE = false
 


### PR DESCRIPTION
This fixes #163, allowing player to bring back the Ashley suplex glitch, thanks to @linkthehylian for suggesting it & helping test changes too!

Video: https://twitter.com/linkthehyIian/status/1514764457578180643

Method: https://github.com/nipkownix/re4_tweaks/issues/163#issuecomment-1099741577

I was hoping that the patch could also act as a fix to allow Ashley to Kick instead (the way they added the Ashley-check to the suplex func meant Ashley wouldn't have any action at all for downed enemies...), but right now it seems this fix doesn't actually work for that... but at least this lets us control it at runtime though.

Maybe looking into `em10ActEvtSetKick` some more could let us get Kick working, seems to have a bunch of player-type checks inside it at least, I guess something there must be failing. (if anyone is able to post a save just before where Suplex is performed that would help a lot, should be able to use Debug Menu to open savegame screen)

Tested with 1.1.0/1.0.6/1.0.6dbg/1.0.6jpn, the hook::patterns are found for them all at least, haven't tried the Suplex out myself though, but @linkthehylian reported that it worked for enabling the glitch at runtime though, not sure what game version they used.
