### PR TITLE
OverrideCostumes: write setting value to INI

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -533,6 +533,7 @@ void Settings::WriteSettings()
 	iniReader.WriteBoolean("FRAME RATE", "FixAshleyBustPhysics", cfg.bFixAshleyBustPhysics);
 
 	// MISC
+	iniReader.WriteBoolean("MISC", "OverrideCostumes", cfg.bOverrideCostumes);
 	iniReader.WriteString("MISC", "LeonCostume", " " + std::string(sLeonCostumeNames[(int)cfg.CostumeOverride.Leon]));
 	iniReader.WriteString("MISC", "AshleyCostume", " " + std::string(sAshleyCostumeNames[(int)cfg.CostumeOverride.Ashley]));
 	iniReader.WriteString("MISC", "AdaCostume", " " + std::string(sAdaCostumeNames[(int)cfg.CostumeOverride.Ada]));


### PR DESCRIPTION
Small thing I noticed, seems OverrideCostumes setting is read from INI, but never got written back, don't think that was intentional, so here's a quick fix 😸 