### PR TITLE
AudioTweaks: fixup settings for INI overrides, & speedup build/startup

### DIFF
--- a/dist/Bin32/re4_tweaks/setting_overrides/overrides_info.txt
+++ b/dist/Bin32/re4_tweaks/setting_overrides/overrides_info.txt
@@ -5,5 +5,8 @@ This should be useful if you're creating a mod that depends on a certain re4_twe
 In that case you can ship a "Bin32\re4_tweaks\setting_overrides\MyCoolMod.ini" with your mod which includes the setting values you require.
 (recommend including the full folder structure with your mod, Bin32 -> re4_tweaks -> setting_overrides, only the folders themselves & your override INI are needed)
 
+Any settings in your override-INI will always override the users saved INI file, so please make sure to only include settings that your mod actually requires!
+(in other words, please try to keep your override-INI trimmed down to the minimum settings needed)
+
 This will also allow settings to be preserved across any re4_tweaks updates that might have changed the INI file.
 You can use this to your advantage to keep your own personal settings saved too, just copy your re4_tweaks INI into this folder!

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -304,4 +304,10 @@ void Init_DisplayTweaks()
 		if (cfg.bDisableFilmGrain)
 			Logging::Log() << "DisableFilmGrain applied";
 	}
+
+	// Disable Windows DPI scaling
+	if (cfg.bFixDPIScale)
+	{
+		SetProcessDPIAware();
+	}
 }

--- a/dllmain/LoggingInit.cpp
+++ b/dllmain/LoggingInit.cpp
@@ -32,6 +32,9 @@ void LogSettings()
 	sprintf(settingBuf, "| %-30s | %15s |", "DisableVsync", cfg.bDisableVsync ? "true" : "false");
 	Logging::Log() << settingBuf;
 
+	sprintf(settingBuf, "| %-30s | %15s |", "FixDPIScale", cfg.bFixDPIScale ? "true" : "false");
+	Logging::Log() << settingBuf;
+
 	sprintf(settingBuf, "| %-30s | %15s |", "FixDisplayMode", cfg.bFixDisplayMode ? "true" : "false");
 	Logging::Log() << settingBuf;
 

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -339,6 +339,7 @@ void Settings::ReadSettings(std::string_view ini_path)
 
 	cfg.bFixUltraWideAspectRatio = iniReader.ReadBoolean("DISPLAY", "FixUltraWideAspectRatio", cfg.bFixUltraWideAspectRatio);
 	cfg.bDisableVsync = iniReader.ReadBoolean("DISPLAY", "DisableVsync", cfg.bDisableVsync);
+	cfg.bFixDPIScale = iniReader.ReadBoolean("DISPLAY", "FixDPIScale", cfg.bFixDPIScale);
 	cfg.bFixDisplayMode = iniReader.ReadBoolean("DISPLAY", "FixDisplayMode", cfg.bFixDisplayMode);
 	cfg.iCustomRefreshRate = iniReader.ReadInteger("DISPLAY", "CustomRefreshRate", cfg.iCustomRefreshRate);
 	cfg.bRestorePickupTransparency = iniReader.ReadBoolean("DISPLAY", "RestorePickupTransparency", cfg.bRestorePickupTransparency);
@@ -548,6 +549,7 @@ void Settings::WriteSettings()
 	iniReader.WriteFloat("DISPLAY", "FOVAdditional", cfg.fFOVAdditional);
 	iniReader.WriteBoolean("DISPLAY", "FixUltraWideAspectRatio", cfg.bFixUltraWideAspectRatio);
 	iniReader.WriteBoolean("DISPLAY", "DisableVsync", cfg.bDisableVsync);
+	iniReader.WriteBoolean("DISPLAY", "FixDPIScale", cfg.bFixDPIScale);
 	iniReader.WriteBoolean("DISPLAY", "FixDisplayMode", cfg.bFixDisplayMode);
 	iniReader.WriteInteger("DISPLAY", "CustomRefreshRate", cfg.iCustomRefreshRate);
 	iniReader.WriteBoolean("DISPLAY", "RestorePickupTransparency", cfg.bRestorePickupTransparency);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -353,13 +353,13 @@ void Settings::ReadSettings(std::string_view ini_path)
 	cfg.bRememberWindowPos = iniReader.ReadBoolean("DISPLAY", "RememberWindowPos", cfg.bRememberWindowPos);
 
 	// AUDIO
-	cfg.fVolumeBGM = iniReader.ReadFloat("AUDIO", "VolumeBGM", 1.0f);
+	cfg.fVolumeBGM = iniReader.ReadFloat("AUDIO", "VolumeBGM", cfg.fVolumeBGM);
 	cfg.fVolumeBGM = fmin(fmax(cfg.fVolumeBGM, 0.0f), 1.0f); // limit between 0.0 - 1.0
 
-	cfg.fVolumeSE = iniReader.ReadFloat("AUDIO", "VolumeSE", 1.0f);
+	cfg.fVolumeSE = iniReader.ReadFloat("AUDIO", "VolumeSE", cfg.fVolumeSE);
 	cfg.fVolumeSE = fmin(fmax(cfg.fVolumeSE, 0.0f), 1.0f); // limit between 0.0 - 1.0
 
-	cfg.fVolumeCutscene = iniReader.ReadFloat("AUDIO", "VolumeCutscene", 1.0f);
+	cfg.fVolumeCutscene = iniReader.ReadFloat("AUDIO", "VolumeCutscene", cfg.fVolumeCutscene);
 	cfg.fVolumeCutscene = fmin(fmax(cfg.fVolumeCutscene, 0.0f), 1.0f); // limit between 0.0 - 1.0
 
 	// MOUSE

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -392,11 +392,7 @@ void Settings::ReadSettings(std::string_view ini_path)
 	cfg.bRemoveExtraXinputDeadzone = iniReader.ReadBoolean("CONTROLLER", "RemoveExtraXinputDeadzone", cfg.bRemoveExtraXinputDeadzone);
 
 	cfg.fXinputDeadzone = iniReader.ReadFloat("CONTROLLER", "XinputDeadzone", cfg.fXinputDeadzone);
-	if (cfg.fXinputDeadzone < 0.0f)
-		cfg.fXinputDeadzone = 0.0f;
-
-	if (cfg.fXinputDeadzone > 3.0f)
-		cfg.fXinputDeadzone = 3.0f;
+	cfg.fXinputDeadzone = fmin(fmax(cfg.fXinputDeadzone, 0.0f), 3.5f); // limit between 0.0 - 3.5
 
 	// FRAME RATE
 	cfg.bFixFallingItemsSpeed = iniReader.ReadBoolean("FRAME RATE", "FixFallingItemsSpeed", cfg.bFixFallingItemsSpeed);
@@ -444,11 +440,7 @@ void Settings::ReadSettings(std::string_view ini_path)
 	cfg.bAshleyJPCameraAngles = iniReader.ReadBoolean("MISC", "AshleyJPCameraAngles", cfg.bAshleyJPCameraAngles);
 
 	cfg.iViolenceLevelOverride = iniReader.ReadInteger("MISC", "ViolenceLevelOverride", cfg.iViolenceLevelOverride);
-	if (cfg.iViolenceLevelOverride < -1)
-		cfg.iViolenceLevelOverride = -1;
-
-	if (cfg.iViolenceLevelOverride > 2)
-		cfg.iViolenceLevelOverride = 2;
+	cfg.iViolenceLevelOverride = min(max(cfg.iViolenceLevelOverride, -1), 2); // limit between -1 to 2
 
 	cfg.bAllowSellingHandgunSilencer = iniReader.ReadBoolean("MISC", "AllowSellingHandgunSilencer", cfg.bAllowSellingHandgunSilencer);
 	cfg.bAllowMafiaLeonCutscenes = iniReader.ReadBoolean("MISC", "AllowMafiaLeonCutscenes", cfg.bAllowMafiaLeonCutscenes);
@@ -495,11 +487,7 @@ void Settings::ReadSettings(std::string_view ini_path)
 	
 	// IMGUI
 	cfg.fFontSize = iniReader.ReadFloat("IMGUI", "FontSize", cfg.fFontSize);
-	if (cfg.fFontSize < 1.0f)
-		cfg.fFontSize = 1.0f;
-
-	if (cfg.fFontSize > 1.3f)
-		cfg.fFontSize = 1.3f;
+	cfg.fFontSize = fmin(fmax(cfg.fFontSize, 1.0f), 1.3f); // limit between 1.0 - 1.3
 
 	cfg.bDisableMenuTip = iniReader.ReadBoolean("IMGUI", "DisableMenuTip", cfg.bDisableMenuTip);
 

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -12,6 +12,7 @@ struct Settings
 	bool bEnableFOV = false;
 	bool bFixUltraWideAspectRatio = true;
 	bool bDisableVsync = false;
+	bool bFixDPIScale = true;
 	bool bFixDisplayMode = true;
 	int iCustomRefreshRate = -1;
 	bool bRestorePickupTransparency = true;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -26,9 +26,9 @@ struct Settings
 	bool bRememberWindowPos = false;
 
 	// AUDIO
-	float fVolumeBGM;
-	float fVolumeSE;
-	float fVolumeCutscene;
+	float fVolumeBGM = 1.0f;
+	float fVolumeSE = 1.0f;
+	float fVolumeCutscene = 1.0f;
 
 	// MOUSE
 	bool bUseMouseTurning = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -215,7 +215,7 @@ void cfgMenuRender()
 					ImGui::PushItemWidth(170);
 					if (!cfg.bEnableFOV)
 						cfg.fFOVAdditional = 0.0f;
-					ImGui::SliderFloat("FOV Slider", &cfg.fFOVAdditional, 0.0f, 50.0f, "%.0f");
+					ImGui::SliderFloat("FOV Slider", &cfg.fFOVAdditional, 0.0f, 50.0f, "%.0f", ImGuiSliderFlags_AlwaysClamp);
 					ImGui::PopItemWidth();
 
 					ImGui::EndTable();
@@ -567,7 +567,7 @@ void cfgMenuRender()
 					ImGui::TableNextColumn();
 					ImGui::Dummy(ImVec2(0.0f, 12.0f));
 					ImGui::PushItemWidth(170);
-					ImGui::SliderFloat("Deadzone Slider", &cfg.fXinputDeadzone, 0.0f, 3.5f, "%.2f");
+					ImGui::SliderFloat("Deadzone Slider", &cfg.fXinputDeadzone, 0.0f, 3.5f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 					ImGui::PopItemWidth();
 
 					if (ImGui::IsItemEdited())

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -249,6 +249,18 @@ void cfgMenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				// FixDPIScale
+				if (ImGui::Checkbox("FixDPIScale", &cfg.bFixDPIScale))
+				{
+					cfg.HasUnsavedChanges = true;
+					NeedsToRestart = true;
+				}
+				ImGui::TextWrapped("Forces game to run at normal 100%% DPI scaling, fixes resolution issues for players that have above 100%% DPI scaling set.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// FixDisplayMode
 				if (ImGui::Checkbox("FixDisplayMode", &cfg.bFixDisplayMode))
 				{

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -99,9 +99,18 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\external\Hooking\Hook.cpp" />
-    <ClCompile Include="..\external\Hooking\HotPatch.cpp" />
-    <ClCompile Include="..\external\Hooking\IATPatch.cpp" />
+    <ClCompile Include="..\external\Hooking\Hook.cpp">
+      <Optimization>MaxSpeed</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
+    <ClCompile Include="..\external\Hooking\HotPatch.cpp">
+      <Optimization>MaxSpeed</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
+    <ClCompile Include="..\external\Hooking\IATPatch.cpp">
+      <Optimization>MaxSpeed</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
     <ClCompile Include="..\external\imgui\imgui.cpp" />
     <ClCompile Include="..\external\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\external\imgui\imgui_draw.cpp" />
@@ -112,7 +121,10 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     <ClCompile Include="..\external\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\external\Logging\Logging.cpp" />
     <ClCompile Include="..\external\miniz\miniz.c" />
-    <ClCompile Include="..\external\ModUtils\Patterns.cpp" />
+    <ClCompile Include="..\external\ModUtils\Patterns.cpp">
+      <Optimization>MaxSpeed</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
     <ClCompile Include="..\includes\stdafx.cpp" />
     <ClCompile Include="..\Wrappers\wrapper.cpp" />
     <ClCompile Include="60fpsFixes.cpp" />

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -101,18 +101,9 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\external\Hooking\Hook.cpp">
-      <Optimization>MaxSpeed</Optimization>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-    </ClCompile>
-    <ClCompile Include="..\external\Hooking\HotPatch.cpp">
-      <Optimization>MaxSpeed</Optimization>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-    </ClCompile>
-    <ClCompile Include="..\external\Hooking\IATPatch.cpp">
-      <Optimization>MaxSpeed</Optimization>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-    </ClCompile>
+    <ClCompile Include="..\external\Hooking\Hook.cpp" />
+    <ClCompile Include="..\external\Hooking\HotPatch.cpp" />
+    <ClCompile Include="..\external\Hooking\IATPatch.cpp" />
     <ClCompile Include="..\external\imgui\imgui.cpp" />
     <ClCompile Include="..\external\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\external\imgui\imgui_draw.cpp" />
@@ -124,8 +115,8 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     <ClCompile Include="..\external\Logging\Logging.cpp" />
     <ClCompile Include="..\external\miniz\miniz.c" />
     <ClCompile Include="..\external\ModUtils\Patterns.cpp">
-      <Optimization>MaxSpeed</Optimization>
-      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MaxSpeed</Optimization>
+      <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Default</BasicRuntimeChecks>
     </ClCompile>
     <ClCompile Include="..\includes\stdafx.cpp" />
     <ClCompile Include="..\Wrappers\wrapper.cpp" />

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -54,6 +54,7 @@
       <AdditionalIncludeDirectories>..\settings;..\includes;..\external;..\external\ModUtils;..\external\injector\include;..\external\inireader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -79,6 +80,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
       <AdditionalIncludeDirectories>..\settings;..\includes;..\external;..\external\ModUtils;..\external\injector\include;..\external\inireader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -12,6 +12,9 @@ FixUltraWideAspectRatio = true
 ; Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.
 DisableVsync = false
 
+; Forces game to run at normal 100% DPI scaling, fixes resolution issues for players that have above 100% DPI scaling set.
+FixDPIScale = true
+
 ; Allows the game to use non-60Hz refresh rates in fullscreen, fixing the black screen issue people have
 ; when starting it.
 FixDisplayMode = true


### PR DESCRIPTION
Another PR for you :p mainly to make sure the new VolumeBGM/SE/etc settings work with override files too. (should have added this in the PR for it earlier, ah well)

To sweeten up this PR I also found a way to speedup debug startup time by a ton, just set some files that we aren't likely to try debugging/stepping-thru to use full optimization, now instead of needing to wait 10+ seconds after starting debug, game should start almost instantly when running under debugger, and AFAIK it shouldn't affect us trying to breakpoint any of our code :)

(E: changed it to only affect Patterns.cpp instead, seems that's the main file that affected startup speed)

E: also found a nice build-time speedup as well, release rebuild went from 30 seconds to ~6 for me now, nice 🐱 