### PR TITLE
vcxproj: use %BIO4_BIN% environment variable as DLL dest path

### DIFF
--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -61,7 +61,7 @@
       <ModuleDefinitionFile>..\Wrappers\wrapper.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(TargetDir)$(TargetFileName)" "E:\SteamLibrary\steamapps\common\Resident Evil 4\Bin32\$(TargetFileName)"</Command>
+      <Command>copy /Y "$(TargetDir)$(TargetFileName)" "%BIO4_BIN%\$(TargetFileName)"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
       <Command>del gitparams.h
@@ -89,7 +89,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
       </AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>copy /Y "$(TargetDir)$(TargetFileName)" "E:\SteamLibrary\steamapps\common\Resident Evil 4\Bin32\$(TargetFileName)"</Command>
+      <Command>copy /Y "$(TargetDir)$(TargetFileName)" "%BIO4_BIN%\$(TargetFileName)"</Command>
     </PostBuildEvent>
     <PreBuildEvent>
       <Command>del gitparams.h

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -23,12 +23,18 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <LocalDebuggerCommand>$(BIO4_BIN)\bio4.exe</LocalDebuggerCommand>
+    <LocalDebuggerWorkingDirectory>$(BIO4_BIN)</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
+    <LocalDebuggerCommand>$(BIO4_BIN)\bio4.exe</LocalDebuggerCommand>
+    <LocalDebuggerWorkingDirectory>$(BIO4_BIN)</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Really wish I'd thought of this sooner, don't currently have an E:\ drive on this PC so I've had to edit the project settings every time I've cloned the repo :p, with this we should be able to have it use our own paths automatically instead.

The env var can be added pretty easily, https://thegeekpage.com/environment-variables-in-windows-11/ mentions a pretty simple way (on Win11 you can pretty much just type "Env" into start menu and it should find it for you)

It'd be nice if we could fill the Debugging settings to point at bio4.exe automatically as well, but think that isn't saved in .vcxproj...

E: oh seems debugging stuff can be copied from the .user file into .vcxproj, sweet, added it below. (wouldn't work with % for some reason but luckily $ worked)