### PR TITLE
FixDitmanGlitch: fixes the ditman speedup glitch

### DIFF
--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -408,6 +408,61 @@ struct SYSTEM_SAVE
 static_assert(sizeof(SYSTEM_SAVE) == 0xA0, "sizeof(SYSTEM_SAVE)"); // TODO: find if this size is correct
 
 #pragma pack(push, 1)
+struct MOTION_INFO
+{
+  int fcvDataPtr_0;
+  uint32_t* animDataPtr_4;
+  int16_t field_8;
+  int field_A;
+  int16_t field_E;
+  int field_10;
+  int16_t field_14;
+  int field_16;
+  int16_t field_1A;
+  int field_1C;
+  float frameCount_20;
+  float frameCurrent_24;
+  float frameCurrent_Backup_28;
+  float framePrev_2C;
+  uint8_t numAnimNodes_30;
+  uint8_t unk_31[3];
+  int animNodeAddrs_34;
+  void* animDescPtr_38;
+  uint16_t field_3C;
+  uint16_t field_3E;
+  uint16_t motionFlags_40;
+  uint16_t field_42;
+  uint32_t flags_44;
+  Vec field_48;
+  Vec field_54;
+  Vec field_60;
+  float field_6C;
+  float field_70;
+  float field_74;
+  float field_78;
+  float field_7C;
+  float field_80;
+  Vec field_84;
+  Vec field_90;
+  Vec field_9C;
+  uint16_t* field_A8;
+  int16_t field_AC;
+  int16_t field_AE;
+  int16_t field_B0;
+  int16_t flags_B2;
+  int field_B4;
+  float cur_frame_B8;
+  uint16_t numFrames_BC;
+  uint8_t unk_BE[2];
+  float speed_C0;
+  uint8_t field_C4;
+  uint8_t field_C5;
+  uint8_t unk_C6[2];
+  float field_C8;
+  uint8_t* field_CC;
+};
+static_assert(sizeof(MOTION_INFO) == 0xD0, "sizeof(MOTION_INFO)");
+
 struct cPlayer // unsure if correct name!
 {
   /* 0x000 */ uint8_t unk0[0x94];
@@ -416,10 +471,12 @@ struct cPlayer // unsure if correct name!
   /* 0x09C */ float Z;
   /* 0x0A0 */ float unkA0;
   /* 0x0A4 */ float Angle;
+  /* 0x0A8 */ uint8_t unk_A8[0x1D8 - 0xA8];
+  /* 0x1D8 */ MOTION_INFO MotInfo_1D8;
   /* goes to 7F0+ */
 };
 #pragma pack(pop)
-static_assert(sizeof(cPlayer) == 0xA8, "sizeof(cPlayer)"); // TODO: nowhere near the correct size!
+static_assert(sizeof(cPlayer) == 0x2A8, "sizeof(cPlayer)"); // TODO: nowhere near the correct size!
 
 struct DatTblEntry
 {

--- a/dllmain/LoggingInit.cpp
+++ b/dllmain/LoggingInit.cpp
@@ -197,6 +197,9 @@ void LogSettings()
 	sprintf(settingBuf, "| %-30s | %15s |", "AllowAshleySuplex", cfg.bAllowAshleySuplex ? "true" : "false");
 	Logging::Log() << settingBuf;
 
+	sprintf(settingBuf, "| %-30s | %15s |", "FixDitmanGlitch", cfg.bFixDitmanGlitch ? "true" : "false");
+	Logging::Log() << settingBuf;
+
 	sprintf(settingBuf, "| %-30s | %15s |", "UseSprintToggle", cfg.bUseSprintToggle ? "true" : "false");
 	Logging::Log() << settingBuf;
 

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -463,6 +463,7 @@ void Settings::ReadSettings(std::string_view ini_path)
 	cfg.bAllowMafiaLeonCutscenes = iniReader.ReadBoolean("MISC", "AllowMafiaLeonCutscenes", cfg.bAllowMafiaLeonCutscenes);
 	cfg.bSilenceArmoredAshley = iniReader.ReadBoolean("MISC", "SilenceArmoredAshley", cfg.bSilenceArmoredAshley);
 	cfg.bAllowAshleySuplex = iniReader.ReadBoolean("MISC", "AllowAshleySuplex", cfg.bAllowAshleySuplex);
+	cfg.bFixDitmanGlitch = iniReader.ReadBoolean("MISC", "FixDitmanGlitch", cfg.bFixDitmanGlitch);
 	cfg.bUseSprintToggle = iniReader.ReadBoolean("MISC", "UseSprintToggle", cfg.bUseSprintToggle);
 	cfg.bDisableQTE = iniReader.ReadBoolean("MISC", "DisableQTE", cfg.bDisableQTE);
 	cfg.bAutomaticMashingQTE = iniReader.ReadBoolean("MISC", "AutomaticMashingQTE", cfg.bAutomaticMashingQTE);
@@ -622,6 +623,7 @@ DWORD WINAPI WriteSettingsThread(LPVOID lpParameter)
 	iniReader.WriteBoolean("MISC", "AllowMafiaLeonCutscenes", cfg.bAllowMafiaLeonCutscenes);
 	iniReader.WriteBoolean("MISC", "SilenceArmoredAshley", cfg.bSilenceArmoredAshley);
 	iniReader.WriteBoolean("MISC", "AllowAshleySuplex", cfg.bAllowAshleySuplex);
+	iniReader.WriteBoolean("MISC", "FixDitmanGlitch", cfg.bFixDitmanGlitch);
 	iniReader.WriteBoolean("MISC", "UseSprintToggle", cfg.bUseSprintToggle);
 	iniReader.WriteBoolean("MISC", "DisableQTE", cfg.bDisableQTE);
 	iniReader.WriteBoolean("MISC", "AutomaticMashingQTE", cfg.bAutomaticMashingQTE);

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -42,7 +42,6 @@ struct Settings
 	bool bFixRetryLoadMouseSelector = true;
 
 	// KEYBOARD
-	bool bUseSprintToggle = false;
 	bool bFallbackToEnglishKeyIcons = true;
 	std::string sFlipItemUp = "HOME";
 	std::string sFlipItemDown = "END";
@@ -83,6 +82,8 @@ struct Settings
 	bool bAllowMafiaLeonCutscenes = true;
 	bool bSilenceArmoredAshley = false;
 	bool bAllowAshleySuplex = false;
+	bool bFixDitmanGlitch = false;
+	bool bUseSprintToggle = false;
 	bool bDisableQTE = false;
 	bool bAutomaticMashingQTE = false;
 	bool bSkipIntroLogos = false;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -793,6 +793,14 @@ void cfgMenuRender()
 				ImGui::Separator();
 				ImGui::Spacing();
 
+				// FixDitmanGlitch
+				cfg.HasUnsavedChanges |= ImGui::Checkbox("FixDitmanGlitch", &cfg.bFixDitmanGlitch);
+				ImGui::TextWrapped("Fixes the Ditman glitch, which would allow players to increase their walk speed.");
+
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
+
 				// UseSprintToggle
 				cfg.HasUnsavedChanges |= ImGui::Checkbox("UseSprintToggle", &cfg.bUseSprintToggle);
 				ImGui::TextWrapped("Changes sprint key to act like a toggle instead of needing to be held.");

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -177,6 +177,10 @@ SilenceArmoredAshley = false
 ; (previously was only possible in the initial NTSC GameCube ver., was patched out in all later ports.)
 AllowAshleySuplex = false
 
+; Fixes the Ditman glitch, which would allow players to increase their walk speed.
+; Not recommended, but mod makers may be interested in enabling this (see Bin32/re4_tweaks/setting_overrides/overrides_info.txt)
+FixDitmanGlitch = false
+
 ; Changes sprint key to act like a toggle instead of needing to be held.
 UseSprintToggle = false
 


### PR DESCRIPTION
As requested in #213 

Don't know whether you want to add this or not, think it might be useful for mod makers since they might not want players to speedrun through their mod (so they could use a settings override file to try forcing this enabled)

Besides that I'm not really sure if it has that much use, tho maybe there's some players that would like to force themselves to play without glitches too, guess this could maybe help to ensure that.

Should work on all the usual EXEs.

E: hm, probably should have documented what actually caused the glitch too...
E2: done