### PR TITLE
MultithreadFix: slight FPS boost via multithread improvements

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -166,6 +166,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->bRemove16by10BlackBars = iniReader.ReadBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 
 	pConfig->bReplaceFramelimiter = iniReader.ReadBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
+	pConfig->bMultithreadFix = iniReader.ReadBoolean("DISPLAY", "MultithreadFix", pConfig->bMultithreadFix);
 	pConfig->bFixDPIScale = iniReader.ReadBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	pConfig->bFixDisplayMode = iniReader.ReadBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
 	pConfig->iCustomRefreshRate = iniReader.ReadInteger("DISPLAY", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -681,7 +682,9 @@ void WriteSettings(std::string_view iniPath, bool trainerIni)
 	iniReader.WriteBoolean("DISPLAY", "StretchFullscreenImages", pConfig->bStretchFullscreenImages);
 	iniReader.WriteBoolean("DISPLAY", "StretchVideos", pConfig->bStretchVideos);
 	iniReader.WriteBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
+
 	iniReader.WriteBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
+	iniReader.WriteBoolean("DISPLAY", "MultithreadFix", pConfig->bMultithreadFix);
 	iniReader.WriteBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	iniReader.WriteBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
 	iniReader.WriteInteger("DISPLAY", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -837,6 +840,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "StretchVideos", pConfig->bStretchVideos ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "MultithreadFix", pConfig->bMultithreadFix ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDPIScale", pConfig->bFixDPIScale ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDisplayMode", pConfig->bFixDisplayMode ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "CustomRefreshRate", pConfig->iCustomRefreshRate);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -166,7 +166,6 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->bRemove16by10BlackBars = iniReader.ReadBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 
 	pConfig->bReplaceFramelimiter = iniReader.ReadBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
-	pConfig->bMultithreadFix = iniReader.ReadBoolean("DISPLAY", "MultithreadFix", pConfig->bMultithreadFix);
 	pConfig->bFixDPIScale = iniReader.ReadBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	pConfig->bFixDisplayMode = iniReader.ReadBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
 	pConfig->iCustomRefreshRate = iniReader.ReadInteger("DISPLAY", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -268,6 +267,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->bFixQTE = iniReader.ReadBoolean("FRAME RATE", "FixQTE", pConfig->bFixQTE);
 	pConfig->bFixAshleyBustPhysics = iniReader.ReadBoolean("FRAME RATE", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics);
 	pConfig->bEnableFastMath = iniReader.ReadBoolean("FRAME RATE", "EnableFastMath", pConfig->bEnableFastMath);
+	pConfig->bMultithreadFix = iniReader.ReadBoolean("FRAME RATE", "MultithreadFix", pConfig->bMultithreadFix);
 	pConfig->bPrecacheModels = iniReader.ReadBoolean("FRAME RATE", "PrecacheModels", pConfig->bPrecacheModels);
 
 	// MISC
@@ -684,7 +684,6 @@ void WriteSettings(std::string_view iniPath, bool trainerIni)
 	iniReader.WriteBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 
 	iniReader.WriteBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
-	iniReader.WriteBoolean("DISPLAY", "MultithreadFix", pConfig->bMultithreadFix);
 	iniReader.WriteBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	iniReader.WriteBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
 	iniReader.WriteInteger("DISPLAY", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -757,6 +756,7 @@ void WriteSettings(std::string_view iniPath, bool trainerIni)
 	iniReader.WriteBoolean("FRAME RATE", "FixQTE", pConfig->bFixQTE);
 	iniReader.WriteBoolean("FRAME RATE", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics);
 	iniReader.WriteBoolean("FRAME RATE", "EnableFastMath", pConfig->bEnableFastMath);
+	iniReader.WriteBoolean("FRAME RATE", "MultithreadFix", pConfig->bMultithreadFix);
 	iniReader.WriteBoolean("FRAME RATE", "PrecacheModels", pConfig->bPrecacheModels);
 
 	// MISC
@@ -840,7 +840,6 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "StretchVideos", pConfig->bStretchVideos ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter ? "true" : "false");
-	spd::log()->info("| {:<30} | {:>15} |", "MultithreadFix", pConfig->bMultithreadFix ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDPIScale", pConfig->bFixDPIScale ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDisplayMode", pConfig->bFixDisplayMode ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -921,6 +920,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "FixQTE", pConfig->bFixQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixAshleyBustPhysics", pConfig->bFixAshleyBustPhysics ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableFastMath", pConfig->bEnableFastMath ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "MultithreadFix", pConfig->bMultithreadFix ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "PrecacheModels", pConfig->bPrecacheModels ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -17,6 +17,7 @@ public:
 	bool bStretchVideos = false;
 	bool bRemove16by10BlackBars = true;
 	bool bReplaceFramelimiter = true;
+	bool bMultithreadFix = false;
 	bool bFixDPIScale = true;
 	bool bFixDisplayMode = true;
 	int iCustomRefreshRate = -1;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -17,7 +17,6 @@ public:
 	bool bStretchVideos = false;
 	bool bRemove16by10BlackBars = true;
 	bool bReplaceFramelimiter = true;
-	bool bMultithreadFix = false;
 	bool bFixDPIScale = true;
 	bool bFixDisplayMode = true;
 	int iCustomRefreshRate = -1;
@@ -78,6 +77,7 @@ public:
 	bool bFixQTE = true;
 	bool bFixAshleyBustPhysics = true;
 	bool bEnableFastMath = true;
+	bool bMultithreadFix = true;
 	bool bPrecacheModels = false;
 
 	// MISC

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1074,6 +1074,23 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Experimental, can hopefully improve framerate in some areas that had dips.");
 					}
 
+					// MultithreadFix
+					{
+						ImGui_ColumnSwitch();
+
+						if (ImGui::Checkbox("MultithreadFix", &pConfig->bMultithreadFix))
+						{
+							pConfig->HasUnsavedChanges = true;
+							NeedsToRestart = true;
+						}
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Enables fixes for multithreaded DirectX9, giving a slight performance boost");
+						ImGui::TextWrapped("Experimental, in case you have issues with the game crashing/freezing, please try disabling this setting and playing again.");
+					}
+
 					// PrecacheModels
 					{
 						ImGui_ColumnSwitch();

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -28,6 +28,10 @@ Remove16by10BlackBars = true
 ; (experimental, not known if the new framelimiter performs the same as the old one yet)
 ReplaceFramelimiter = true
 
+; Enables fixes for multithreaded DirectX9, for slight performance boost
+; (experimental, unsure how stable this is)
+MultithreadFix = false
+
 ; Forces game to run at normal 100% DPI scaling, fixes resolution issues for players that have above 100% DPI scaling set.
 FixDPIScale = true
 

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -28,10 +28,6 @@ Remove16by10BlackBars = true
 ; (experimental, not known if the new framelimiter performs the same as the old one yet)
 ReplaceFramelimiter = true
 
-; Enables fixes for multithreaded DirectX9, for slight performance boost
-; (experimental, unsure how stable this is)
-MultithreadFix = false
-
 ; Forces game to run at normal 100% DPI scaling, fixes resolution issues for players that have above 100% DPI scaling set.
 FixDPIScale = true
 
@@ -210,6 +206,11 @@ FixAshleyBustPhysics = true
 ; Replaces older math functions in the game with much more optimized equivalents.
 ; Experimental, can hopefully improve framerate in some areas that had dips.
 EnableFastMath = true
+
+; Enables fixes for multithreaded DirectX9, giving a slight performance boost
+; (experimental: in case you have issues with the game crashing/freezing, please try disabling this setting and playing again)
+; If that helps solve the issue for you, please let us know about it at https://github.com/nipkownix/re4_tweaks/issues
+MultithreadFix = true
 
 ; Forces game to fully cache all models in the level after loading in.
 ; May help with framerate drops when viewing a model for the first time.


### PR DESCRIPTION
As mentioned at #44, this removes `D3DCREATE_MULTITHREADED` safety flag for a slight FPS improvement, and adds some fixes for deadlocks caused by flag being removed.

A `MultithreadFix` option is added to [DISPLAY] section of INI to toggle it, haven't added GUI stuff for the setting yet though.

This seems to boost FPS by +40-60 for me when running with framelimiter removed, so hopefully will help with FPS drops when playing normally too.

Haven't tested it that much yet though, would appreciate anyone giving it a try! If you get any crashes/hangs please let me know. (maybe create a `CrashDumps` folder next to bio4.exe first before testing it)

You can grab release build from https://github.com/nipkownix/re4_tweaks/suites/7489522135/artifacts/307461430 - just make sure to edit dinput8.ini and set `MultithreadFix` to true first.