### PR TITLE
ReplaceFramelimiter: implements new reduced-CPU-usage limiter

### DIFF
--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -136,7 +136,7 @@ void FramelimiterHook(uint8_t isAliveEvt_result)
 	if (pConfig->bDisableFramelimiting)
 	{
 		// If framelimiter is disabled, we'll have to figure out elapsed time outside of the FramelimiterLoop fn
-		// (allows DisableFixedFrametime to work properly with framelimiting disabled)
+		// (allows UseDynamicFrametime to work properly with framelimiting disabled)
 		LARGE_INTEGER counter;
 		QueryPerformanceCounter(&counter);
 		double millis_current = (double)counter.QuadPart / FramelimiterFrequency;
@@ -159,7 +159,7 @@ void FramelimiterHook(uint8_t isAliveEvt_result)
 		// TODO: using the actual time elapsed since last frame instead of FramelimiterTargetFrametime would solve slowdown issues
 		// (similar to https://github.com/nipkownix/re4_tweaks/pull/25)
 		// but it's not known how well the game works with values that aren't 0.5 (60fps) or 1 (30fps)
-		// so for now we'll just work pretty much the same as the game itself, unless DisableFixedFrametime is set
+		// so for now we'll just work pretty much the same as the game itself, unless UseDynamicFrametime is set
 		if (!pConfig->bUseDynamicFrametime)
 			timeElapsed = TargetFrametime;
 	}

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -159,6 +159,7 @@ void Framelimiter_Hook(uint8_t isAliveEvt_result)
 
 void Init_DisplayTweaks()
 {
+	// Implements new reduced-CPU-usage limiter
 	if (pConfig->bReplaceFramelimiter)
 	{
 		// nop beginning of framelimiter code (sets up thread affinity to core 0)
@@ -178,6 +179,8 @@ void Init_DisplayTweaks()
 		Patch(framelimiterStart, uint8_t(0x50)); // push eax (pass return value of EventMgr::IsAliveEvt)
 		InjectHook(framelimiterStart + 1, Framelimiter_Hook, PATCH_CALL);
 		Patch(framelimiterStart + 1 + 5, { 0x83, 0xc4, 0x04 }); // add esp, 4 (needed to allow WinMain to exit properly)
+
+		spd::log()->info("Framelimiter replaced");
 	}
 
 	// Fix broken effects

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -17,6 +17,12 @@ bool GameVersionIsDebug()
 	return gameIsDebugBuild;
 }
 
+uint32_t* ptrGameVariableFrameRate;
+int GameVariableFrameRate()
+{
+	return *(int32_t*)(ptrGameVariableFrameRate);
+}
+
 uint32_t* ptrLastUsedDevice = nullptr;
 InputDevices LastUsedDevice()
 {
@@ -165,6 +171,10 @@ bool Init_Game()
 	#ifdef VERBOSE
 	con.AddConcatLog("Game version = ", GameVersion().data());
 	#endif
+
+	// Pointer to users variableframerate setting value
+	pattern = hook::pattern("89 0D ? ? ? ? 0F 95 ? 88 15 ? ? ? ? D9 1D ? ? ? ? A3 ? ? ? ? DB 46 ? D9 1D ? ? ? ? 8B 4E ? 89 0D ? ? ? ? 8B 4D ? 5E");
+	ptrGameVariableFrameRate = *pattern.count(1).get(0).get<uint32_t*>(2);
 
 	// LastUsedDevice pointer
 	pattern = hook::pattern("A1 ? ? ? ? 85 C0 74 ? 83 F8 ? 74 ? 81 F9");

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -24,6 +24,7 @@ extern SND_CTRL* Snd_ctrl_work;
 
 std::string GameVersion();
 bool GameVersionIsDebug();
+int GameVariableFrameRate();
 InputDevices LastUsedDevice();
 bool isController();
 bool isKeyboardMouse();

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -361,6 +361,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	// DEBUG
 	pConfig->bVerboseLog = iniReader.ReadBoolean("DEBUG", "VerboseLog", pConfig->bVerboseLog);
 	pConfig->bNeverHideCursor = iniReader.ReadBoolean("DEBUG", "NeverHideCursor", pConfig->bNeverHideCursor);
+	pConfig->bDisableFixedFrametime = iniReader.ReadBoolean("DEBUG", "DisableFixedFrametime", pConfig->bDisableFixedFrametime);
 	pConfig->bDisableFramelimiting = iniReader.ReadBoolean("DEBUG", "DisableFramelimiting", pConfig->bDisableFramelimiting);
 }
 
@@ -703,5 +704,6 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "VerboseLog", pConfig->bVerboseLog ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "NeverHideCursor", pConfig->bNeverHideCursor ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "DisableFramelimiting", pConfig->bDisableFramelimiting ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "DisableFixedFrametime", pConfig->bDisableFixedFrametime ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 }

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -361,7 +361,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	// DEBUG
 	pConfig->bVerboseLog = iniReader.ReadBoolean("DEBUG", "VerboseLog", pConfig->bVerboseLog);
 	pConfig->bNeverHideCursor = iniReader.ReadBoolean("DEBUG", "NeverHideCursor", pConfig->bNeverHideCursor);
-	pConfig->bDisableFixedFrametime = iniReader.ReadBoolean("DEBUG", "DisableFixedFrametime", pConfig->bDisableFixedFrametime);
+	pConfig->bUseDynamicFrametime = iniReader.ReadBoolean("DEBUG", "UseDynamicFrametime", pConfig->bUseDynamicFrametime);
 	pConfig->bDisableFramelimiting = iniReader.ReadBoolean("DEBUG", "DisableFramelimiting", pConfig->bDisableFramelimiting);
 }
 
@@ -703,7 +703,7 @@ void Config::LogSettings()
 	spd::log()->info("+ DEBUG--------------------------+-----------------+");
 	spd::log()->info("| {:<30} | {:>15} |", "VerboseLog", pConfig->bVerboseLog ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "NeverHideCursor", pConfig->bNeverHideCursor ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "UseDynamicFrametime", pConfig->bUseDynamicFrametime ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "DisableFramelimiting", pConfig->bDisableFramelimiting ? "true" : "false");
-	spd::log()->info("| {:<30} | {:>15} |", "DisableFixedFrametime", pConfig->bDisableFixedFrametime ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 }

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -145,6 +145,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->bRemove16by10BlackBars = iniReader.ReadBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 
 	pConfig->bDisableVsync = iniReader.ReadBoolean("DISPLAY", "DisableVsync", pConfig->bDisableVsync);
+	pConfig->bReplaceFramelimiter = iniReader.ReadBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
 	pConfig->bFixDPIScale = iniReader.ReadBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	pConfig->bFixDisplayMode = iniReader.ReadBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
 	pConfig->iCustomRefreshRate = iniReader.ReadInteger("DISPLAY", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -360,6 +361,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	// DEBUG
 	pConfig->bVerboseLog = iniReader.ReadBoolean("DEBUG", "VerboseLog", pConfig->bVerboseLog);
 	pConfig->bNeverHideCursor = iniReader.ReadBoolean("DEBUG", "NeverHideCursor", pConfig->bNeverHideCursor);
+	pConfig->bDisableFramelimiting = iniReader.ReadBoolean("DEBUG", "DisableFramelimiting", pConfig->bDisableFramelimiting);
 }
 
 std::mutex settingsThreadRunningMutex;
@@ -414,6 +416,7 @@ DWORD WINAPI WriteSettingsThread(LPVOID lpParameter)
 	iniReader.WriteBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 	
 	iniReader.WriteBoolean("DISPLAY", "DisableVsync", pConfig->bDisableVsync);
+	iniReader.WriteBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
 	iniReader.WriteBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	iniReader.WriteBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
 	iniReader.WriteInteger("DISPLAY", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -556,6 +559,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "StretchVideos", pConfig->bStretchVideos ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "DisableVsync", pConfig->bDisableVsync ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDPIScale", pConfig->bFixDPIScale ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDisplayMode", pConfig->bFixDisplayMode ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "CustomRefreshRate", pConfig->iCustomRefreshRate);
@@ -698,5 +702,6 @@ void Config::LogSettings()
 	spd::log()->info("+ DEBUG--------------------------+-----------------+");
 	spd::log()->info("| {:<30} | {:>15} |", "VerboseLog", pConfig->bVerboseLog ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "NeverHideCursor", pConfig->bNeverHideCursor ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "DisableFramelimiting", pConfig->bDisableFramelimiting ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 }

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -138,13 +138,14 @@ void Config::ReadSettings(std::string_view ini_path)
 	else
 		pConfig->bEnableFOV = false;
 
+	pConfig->bDisableVsync = iniReader.ReadBoolean("DISPLAY", "DisableVsync", pConfig->bDisableVsync);
+
 	pConfig->bUltraWideAspectSupport = iniReader.ReadBoolean("DISPLAY", "UltraWideAspectSupport", pConfig->bUltraWideAspectSupport);
 	pConfig->bSideAlignHUD = iniReader.ReadBoolean("DISPLAY", "SideAlignHUD", pConfig->bSideAlignHUD);
 	pConfig->bStretchFullscreenImages = iniReader.ReadBoolean("DISPLAY", "StretchFullscreenImages", pConfig->bStretchFullscreenImages);
 	pConfig->bStretchVideos = iniReader.ReadBoolean("DISPLAY", "StretchVideos", pConfig->bStretchVideos);
 	pConfig->bRemove16by10BlackBars = iniReader.ReadBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 
-	pConfig->bDisableVsync = iniReader.ReadBoolean("DISPLAY", "DisableVsync", pConfig->bDisableVsync);
 	pConfig->bReplaceFramelimiter = iniReader.ReadBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
 	pConfig->bFixDPIScale = iniReader.ReadBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	pConfig->bFixDisplayMode = iniReader.ReadBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
@@ -409,6 +410,7 @@ DWORD WINAPI WriteSettingsThread(LPVOID lpParameter)
 
 	// DISPLAY
 	iniReader.WriteFloat("DISPLAY", "FOVAdditional", pConfig->fFOVAdditional);
+	iniReader.WriteBoolean("DISPLAY", "DisableVsync", pConfig->bDisableVsync);
 
 	iniReader.WriteBoolean("DISPLAY", "UltraWideAspectSupport", pConfig->bUltraWideAspectSupport);
 	iniReader.WriteBoolean("DISPLAY", "SideAlignHUD", pConfig->bSideAlignHUD);
@@ -416,7 +418,6 @@ DWORD WINAPI WriteSettingsThread(LPVOID lpParameter)
 	iniReader.WriteBoolean("DISPLAY", "StretchVideos", pConfig->bStretchVideos);
 	iniReader.WriteBoolean("DISPLAY", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars);
 	
-	iniReader.WriteBoolean("DISPLAY", "DisableVsync", pConfig->bDisableVsync);
 	iniReader.WriteBoolean("DISPLAY", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter);
 	iniReader.WriteBoolean("DISPLAY", "FixDPIScale", pConfig->bFixDPIScale);
 	iniReader.WriteBoolean("DISPLAY", "FixDisplayMode", pConfig->bFixDisplayMode);
@@ -554,12 +555,12 @@ void Config::LogSettings()
 	// DISPLAY
 	spd::log()->info("+ DISPLAY------------------------+-----------------+");
 	spd::log()->info("| {:<30} | {:>15} |", "FOVAdditional", pConfig->fFOVAdditional);
+	spd::log()->info("| {:<30} | {:>15} |", "DisableVsync", pConfig->bDisableVsync ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "UltraWideAspectSupport", pConfig->bUltraWideAspectSupport ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "SideAlignHUD", pConfig->bSideAlignHUD ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "StretchFullscreenImages", pConfig->bStretchFullscreenImages ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "StretchVideos", pConfig->bStretchVideos ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "Remove16by10BlackBars", pConfig->bRemove16by10BlackBars ? "true" : "false");
-	spd::log()->info("| {:<30} | {:>15} |", "DisableVsync", pConfig->bDisableVsync ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ReplaceFramelimiter", pConfig->bReplaceFramelimiter ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDPIScale", pConfig->bFixDPIScale ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDisplayMode", pConfig->bFixDisplayMode ? "true" : "false");

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -132,6 +132,7 @@ public:
 	// DEBUG
 	bool bVerboseLog = false;
 	bool bNeverHideCursor = false;
+	bool bDisableFixedFrametime = false;
 	bool bDisableFramelimiting = false;
 
 	bool HasUnsavedChanges = false;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -16,6 +16,7 @@ public:
 	bool bStretchVideos = false;
 	bool bRemove16by10BlackBars = true;
 	bool bDisableVsync = false;
+	bool bReplaceFramelimiter = false;
 	bool bFixDPIScale = true;
 	bool bFixDisplayMode = true;
 	int iCustomRefreshRate = -1;
@@ -131,6 +132,7 @@ public:
 	// DEBUG
 	bool bVerboseLog = false;
 	bool bNeverHideCursor = false;
+	bool bDisableFramelimiting = false;
 
 	bool HasUnsavedChanges = false;
 

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -10,13 +10,13 @@ public:
 	// DISPLAY
 	float fFOVAdditional = 0.0f;
 	bool bEnableFOV = false;
+	bool bDisableVsync = false;
 	bool bUltraWideAspectSupport = true;
 	bool bSideAlignHUD = true;
 	bool bStretchFullscreenImages = false;
 	bool bStretchVideos = false;
 	bool bRemove16by10BlackBars = true;
-	bool bDisableVsync = false;
-	bool bReplaceFramelimiter = false;
+	bool bReplaceFramelimiter = true;
 	bool bFixDPIScale = true;
 	bool bFixDisplayMode = true;
 	int iCustomRefreshRate = -1;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -132,7 +132,7 @@ public:
 	// DEBUG
 	bool bVerboseLog = false;
 	bool bNeverHideCursor = false;
-	bool bDisableFixedFrametime = false;
+	bool bUseDynamicFrametime = false;
 	bool bDisableFramelimiting = false;
 
 	bool HasUnsavedChanges = false;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -479,6 +479,23 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.");
 					}
 
+					// ReplaceFramelimiter
+					{
+						ImGui_ColumnSwitch();
+
+						if (ImGui::Checkbox("ReplaceFramelimiter", &pConfig->bReplaceFramelimiter))
+						{
+							pConfig->HasUnsavedChanges = true;
+							NeedsToRestart = true;
+						}
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10));
+						ImGui::TextWrapped("Replaces the games 60/30FPS framelimiter with our own version which can reduce CPU usage quite a bit.");
+						ImGui::TextWrapped("(experimental, not known if the new framelimiter performs the same as the old one yet)");
+					}
+
 					// FixDPIScale
 					{
 						ImGui_ColumnSwitch();

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -422,6 +422,22 @@ void cfgMenuRender()
 							pConfig->fFOVAdditional = 0.0f;
 					}
 
+					// DisableVsync
+					{
+						ImGui_ColumnSwitch();
+
+						if (ImGui::Checkbox("DisableVsync", &pConfig->bDisableVsync))
+						{
+							pConfig->HasUnsavedChanges = true;
+							NeedsToRestart = true;
+						}
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10));
+						ImGui::TextWrapped("Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.");
+					}
+
 					// Aspect ratio tweaks
 					{
 						ImGui_ColumnSwitch();
@@ -461,22 +477,6 @@ void cfgMenuRender()
 						pConfig->HasUnsavedChanges |= ImGui::Checkbox("Remove16by10BlackBars", &pConfig->bRemove16by10BlackBars);
 						ImGui::TextWrapped("Removes top and bottom black bars that are present when playing in 16:10. Will crop a few pixels from each side of the screen.");
 						ImGui::TextWrapped("(Change the resolution for this setting to take effect)");
-					}
-
-					// DisableVsync
-					{
-						ImGui_ColumnSwitch();
-
-						if (ImGui::Checkbox("DisableVsync", &pConfig->bDisableVsync))
-						{
-							pConfig->HasUnsavedChanges = true;
-							NeedsToRestart = true;
-						}
-
-						ImGui_ItemSeparator();
-
-						ImGui::Dummy(ImVec2(10, 10));
-						ImGui::TextWrapped("Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.");
 					}
 
 					// ReplaceFramelimiter

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -492,7 +492,7 @@ void cfgMenuRender()
 						ImGui_ItemSeparator();
 
 						ImGui::Dummy(ImVec2(10, 10));
-						ImGui::TextWrapped("Replaces the games 60/30FPS framelimiter with our own version which can reduce CPU usage quite a bit.");
+						ImGui::TextWrapped("Replaces the games 60/30FPS framelimiter with our own version, which reduces CPU usage quite a lot.");
 						ImGui::TextWrapped("(experimental, not known if the new framelimiter performs the same as the old one yet)");
 					}
 

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -351,6 +351,11 @@ DisableMenuTip = false
 VerboseLog = false
 NeverHideCursor = false
 
+; Passes the actual elapsed frametime to the game instead of a fixed 30/60FPS frametime
+; Should help reduce slowdown in-game when FPS fails to reach the games framerate setting
+; (experimental, certain things may act strange when using non-fixed frametime, especially audio)
+DisableFixedFrametime = false
+
 ; Disables any kind of framelimiting
 ; useful for comparing "true" FPS/frametime when making performance-related changes
 ; (requires ReplaceFramelimiter = true, recommend DisableVSync too)

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -26,6 +26,10 @@ Remove16by10BlackBars = false
 ; Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.
 DisableVsync = false
 
+; Replaces the games 60/30FPS framelimiter with our own version which can reduce CPU usage quite a bit
+; (experimental, not known if the new framelimiter performs the same as the old one yet)
+ReplaceFramelimiter = false
+
 ; Forces game to run at normal 100% DPI scaling, fixes resolution issues for players that have above 100% DPI scaling set.
 FixDPIScale = true
 
@@ -346,4 +350,9 @@ DisableMenuTip = false
 ; Logs extra information.
 VerboseLog = false
 NeverHideCursor = false
+
+; Disables any kind of framelimiting
+; useful for comparing "true" FPS/frametime when making performance-related changes
+; (requires ReplaceFramelimiter = true, recommend DisableVSync too)
+DisableFramelimiting = false
 )"""";

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -4,6 +4,9 @@ const char* defaultSettings = R""""(
 ; Additional FOV value. 20 seems good for most cases.
 FOVAdditional = 0.0
 
+; Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.
+DisableVsync = false
+
 ; Fixes the incorrect aspect ratio when playing in ultrawide resolutions, 
 ; preventing the image from being cut off and the HUD appearing off-screen.
 UltraWideAspectSupport = true
@@ -21,14 +24,11 @@ StretchVideos = false
 
 ; Removes top and bottom black bars that are present when playing in 16:10.
 ; Will crop a few pixels from each side of the screen.
-Remove16by10BlackBars = false
-
-; Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.
-DisableVsync = false
+Remove16by10BlackBars = true
 
 ; Replaces the games 60/30FPS framelimiter with our own version, which reduces CPU usage quite a lot.
 ; (experimental, not known if the new framelimiter performs the same as the old one yet)
-ReplaceFramelimiter = false
+ReplaceFramelimiter = true
 
 ; Forces game to run at normal 100% DPI scaling, fixes resolution issues for players that have above 100% DPI scaling set.
 FixDPIScale = true

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -26,7 +26,7 @@ Remove16by10BlackBars = false
 ; Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.
 DisableVsync = false
 
-; Replaces the games 60/30FPS framelimiter with our own version which can reduce CPU usage quite a bit
+; Replaces the games 60/30FPS framelimiter with our own version, which reduces CPU usage quite a lot.
 ; (experimental, not known if the new framelimiter performs the same as the old one yet)
 ReplaceFramelimiter = false
 
@@ -351,13 +351,13 @@ DisableMenuTip = false
 VerboseLog = false
 NeverHideCursor = false
 
-; Passes the actual elapsed frametime to the game instead of a fixed 30/60FPS frametime
-; Should help reduce slowdown in-game when FPS fails to reach the games framerate setting
+; Passes the actual elapsed frametime to the game instead of a fixed 30/60FPS frametime.
+; Should help reduce slowdown in-game when FPS fails to reach the games framerate setting.
 ; (experimental, certain things may act strange when using non-fixed frametime, especially audio)
 UseDynamicFrametime = false
 
-; Disables any kind of framelimiting
-; useful for comparing "true" FPS/frametime when making performance-related changes
-; (requires ReplaceFramelimiter = true, recommend DisableVSync too)
+; Disables any kind of framelimiting.
+; Useful for comparing "true" FPS/frametime when making performance-related changes.
+; (requires ReplaceFramelimiter = true, recommend DisableVsync too)
 DisableFramelimiting = false
 )"""";

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -354,7 +354,7 @@ NeverHideCursor = false
 ; Passes the actual elapsed frametime to the game instead of a fixed 30/60FPS frametime
 ; Should help reduce slowdown in-game when FPS fails to reach the games framerate setting
 ; (experimental, certain things may act strange when using non-fixed frametime, especially audio)
-DisableFixedFrametime = false
+UseDynamicFrametime = false
 
 ; Disables any kind of framelimiting
 ; useful for comparing "true" FPS/frametime when making performance-related changes


### PR DESCRIPTION
As discussed at https://github.com/nipkownix/re4_tweaks/issues/44#issuecomment-1178293241, this implements the `FPS_ACCURATE` framelimiter from https://github.com/ThirteenAG/d3d9-wrapper/blob/c1480b0c1b40e0ba7b55b8660bd67f911a967421/source/dllmain.cpp#L46

For me this gave a pretty nice CPU usage reduction:
>CPU usage on main menu went from 7% to 1%, ingame from 10% to 4%

[qingsheng8848](https://github.com/nipkownix/re4_tweaks/issues/44#issuecomment-1179459205) also mentioned:
>it works very well, my CPU usage is reduced from 40% to about 20%.

The code is pretty close to the old framelimiter really, but I think the Sleep(1) call helps reduce CPU usage of the busy loop, there's also no longer a 0.01666666... minimum frametime with this so variableframerate above 60 should work better (though still probably has many issues like the ones mentioned in #50)

This also adds two settings to INI [DEBUG] section, `DisableFramelimiting` which should be useful for performance comparisons, and `UseDynamicFrametime`, which makes it pass the actual elapsed frametime to the game, instead of fixed 60/30FPS frametimes - **_this should help with the slowdown issue when framerate drops_**, but not sure how well things will work with non-fixed frametime, likely will have a lot of issues, so it's disabled by default for now.

Using both `DisableFramelimiting` & `UseDynamicFrametime` might come in useful for finding some non-framerate-adjusted things in the game too, eg. I noticed aiming with laser-sight seems slower using mouse to aim when FPS is very high, so I guess that might mean the aim speed is slightly different between 30/60 too. (#258 should fix that)

Haven't added any GUI options for the `ReplaceFramelimiter` setting yet, not really sure how to add stuff without breaking everything... would appreciate if you could show how to add a UI option for it with the new layout 😅 

---

If anyone is willing to help test it out, a release build can be found at https://github.com/nipkownix/re4_tweaks/suites/7489502732/artifacts/307459942 - just be sure to set `ReplaceFramelimiter = true` in the dinput8.ini first!
(should work fine across all the usual EXEs)

We mainly just want to make sure the game still plays fine with this framelimiter in place, no idea if anything might be depending on the previous framelimiter behavior or not. If anyone finds anything broken please let us know!