### PR TITLE
MouseDelta: apply deltaTime, makes aim speed consistent across framerates

### DIFF
--- a/dllmain/KeyboardMouseTweaks.cpp
+++ b/dllmain/KeyboardMouseTweaks.cpp
@@ -180,10 +180,13 @@ void Init_KeyboardMouseTweaks()
 		{
 			void operator()(injector::reg_pack& regs)
 			{
+				double deltaX = 0;
 				if (pConfig->bUseRawMouseInput)
-					*(int32_t*)(ptrMouseDeltaX) = (int32_t)((pInput->raw_mouse_delta_x() / 10.0f) * g_MOUSE_SENS());
+					deltaX = (pInput->raw_mouse_delta_x() / 10.0f) * g_MOUSE_SENS();
 				else
-					*(int32_t*)(ptrMouseDeltaX) = (int32_t)regs.eax;
+					deltaX = double(int(regs.eax));
+
+				*(int32_t*)(ptrMouseDeltaX) = int32_t(deltaX / GlobalPtr()->deltaTime_70);
 			}
 		}; injector::MakeInline<MouseDeltaX>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
 	}
@@ -196,10 +199,13 @@ void Init_KeyboardMouseTweaks()
 		{
 			void operator()(injector::reg_pack& regs)
 			{
+				double deltaY = 0;
 				if (pConfig->bUseRawMouseInput)
-					*(int32_t*)(ptrMouseDeltaY) = -(int32_t)((pInput->raw_mouse_delta_y() / 6.0f) * g_MOUSE_SENS());
+					deltaY = -((pInput->raw_mouse_delta_y() / 6.0f) * g_MOUSE_SENS());
 				else
-					*(int32_t*)(ptrMouseDeltaY) = (int32_t)regs.eax;
+					deltaY = double(int(regs.eax));
+
+				*(int32_t*)(ptrMouseDeltaY) = int32_t(deltaY / GlobalPtr()->deltaTime_70);
 			}
 		}; injector::MakeInline<MouseDeltaY>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
 


### PR DESCRIPTION
Small thing I noticed while testing #257, though even without that you can notice a difference between aim sensitivity at 30 vs 60, this seems to help make them more consistent.

Not sure if the non-rawinput `(ptrMouseDeltaX) = (int32_t)regs.eax;` path might also need deltatime applied too.. will try checking that soon.

E: seems like it might, will update PR in a sec.
~~E2: hmm, can't seem to adjust non-rawinput with the same method, dividing by deltaTime makes aiming go all over the place, even when deltaTime is 1? weird.~~
~~If anyone has any ideas please let me know, otherwise I guess this fix is just for rawinput atm...~~

E3: ah nvm, regs.eax was uint but needed to be int, seems to work fine now, pushed with new fix.