### PR TITLE
Trainer: GUI for trainer related patches / enemy data editing

### DIFF
--- a/dllmain/EndSceneHook.cpp
+++ b/dllmain/EndSceneHook.cpp
@@ -12,6 +12,7 @@
 #include <hashes.h>
 #include "input.hpp"
 #include "resource.h"
+#include "Trainer.h"
 
 EndSceneHook esHook;
 
@@ -278,6 +279,8 @@ void EndSceneHook::EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 	ImGuipInputUpdate();
 
 	ImGui::NewFrame();
+
+	Trainer_Update();
 
 	// Check if the configuration menu binding has been pressed
 	cfgMenuBinding();

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -190,6 +190,35 @@ bool IsGanado(int id) // same as games IsGanado func
 	return id <= 0x20;
 }
 
+const char* emlist_name[] = {
+	"emleon00.esl",
+	"emleon01.esl",
+	"emleon02.esl",
+	"emleon03.esl",
+	"emleon04.esl",
+	"emleon05.esl",
+	"emleon06.esl",
+	"emleon07.esl",
+	"emleon08.esl",
+	"emleon09.esl",
+	"omake00.esl",
+	"omake01.esl",
+	"omake02.esl",
+	"omake03.esl",
+	"omake04.esl",
+	"omake05.esl",
+	"omake06.esl",
+	"omake07.esl",
+	"omake08.esl",
+};
+
+const char* getEmListName(int emListNumber)
+{
+	if (emListNumber >= 0 && emListNumber < 19)
+		return emlist_name[emListNumber];
+	return "unknown";
+}
+
 // Original game funcs
 bool(__cdecl* game_KeyOnCheck_0)(KEY_BTN a1);
 void(__cdecl* game_C_MTXOrtho)(Mtx44 mtx, float PosY, float NegY, float NegX, float PosX, float Near, float Far);

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -5,6 +5,56 @@
 std::string gameVersion;
 bool gameIsDebugBuild = false;
 
+std::unordered_map<int, std::string> EmNames =
+{
+	{0x00, "Player"},
+	{0x50, "EmObj"},
+	{0x51, "EmDoor"},
+	{0x52, "EmWep"},
+	{0x53, "EmBox"},
+	//0x54 unused?
+	{0x55, "EmRack"},
+	{0x56, "EmWindow"},
+	{0x57, "EmTorch"},
+	{0x58, "EmBarrel"},
+	{0x59, "EmTree"},
+	{0x5A, "EmRock"},
+	{0x5B, "EmSwitch"},
+	{0x5C, "EmItem"},
+	{0x5D, "EmHit"},
+	{0x5E, "EmBarred"},
+	{0x5F, "EmMine"},
+	{0x60, "EmShield"},
+	{0x61, "EmBar"},
+};
+
+// a lot missing from here sadly ;_;
+std::unordered_map<int, std::string> UnitBeFlagNames =
+{
+	{ 0x1, "Alive1" },
+	{ 0x2, "Trans" },
+	{ 0x20, "Move" },
+	{ 0x200, "Alive200" },
+	{ 0x800, "NoSuspend" }
+};
+
+std::string cEmMgr::EmIdToName(int id)
+{
+	if (EmNames.count(id))
+		return EmNames[id];
+	std::stringstream ss;
+	ss << "Em" << std::setfill('0') << std::setw(2) << id;
+	return ss.str();
+}
+
+std::string cUnit::GetBeFlagName(int flagIndex)
+{
+	int flagValue = (1 << flagIndex);
+	if (UnitBeFlagNames.count(flagValue))
+		return UnitBeFlagNames[flagValue];
+	return "Bit" + std::to_string(flagIndex);
+}
+
 std::string GameVersion()
 {
 	return gameVersion;
@@ -110,8 +160,8 @@ uint8_t* GameSavePtr()
 	return *g_GameSave_BufPtr;
 }
 
-cManager<cEm>* EmMgr_ptr = nullptr;
-cManager<cEm>* EmMgrPtr()
+cEmMgr* EmMgr_ptr = nullptr;
+cEmMgr* EmMgrPtr()
 {
 	return EmMgr_ptr;
 }
@@ -199,7 +249,7 @@ bool Init_Game()
 
 	// pointer to EmMgr (instance of cManager<cEm>)
 	pattern = hook::pattern("81 E1 01 02 00 00 83 F9 01 75 ? 50 B9 ? ? ? ? E8");
-	EmMgr_ptr = *pattern.count(1).get(0).get<cManager<cEm>*>(0xD);
+	EmMgr_ptr = *pattern.count(1).get(0).get<cEmMgr*>(0xD);
 
 	return true;
 }

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -179,6 +179,17 @@ cEmMgr* EmMgrPtr()
 	return EmMgr_ptr;
 }
 
+bool IsGanado(int id) // same as games IsGanado func
+{
+	if (id == 0x4B || id == 0x4E)
+		return 0;
+	if ((unsigned int)(id - 0x40) <= 0xF)
+		return 1;
+	if (id < 0x10)
+		return 0;
+	return id <= 0x20;
+}
+
 // Original game funcs
 bool(__cdecl* game_KeyOnCheck_0)(KEY_BTN a1);
 void(__cdecl* game_C_MTXOrtho)(Mtx44 mtx, float PosY, float NegY, float NegX, float PosX, float Near, float Far);

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -33,7 +33,7 @@ std::unordered_map<int, std::string> UnitBeFlagNames =
 {
 	{ 0x1, "Alive" },
 	{ 0x2, "Trans" },
-	{ 0x8, "AlternateAmbLightColor" }, // checked by LightSetModel, didn't notice any change
+	{ 0x8, "AltAmbientLightColor" }, // checked by LightSetModel, didn't notice any change
 	{ 0x10, "DrawFootShadow" },
 	{ 0x20, "Move" },
 	{ 0x200, "Dead" }, // maybe dead flag? setting it seems to set Destruct flag, which unsets a bunch of flags including Alive
@@ -47,7 +47,7 @@ std::unordered_map<int, std::string> UnitBeFlagNames =
 	{ 0x20000, "UseSimpleLighting" },
 	{ 0x100000, "ClothNoScaleApply" }, // PenClothMove3
 	{ 0x200000, "ClothReset" }, // PenClothMove3
-	{ 0x1000000, "UseGlobalIllumination" }, // unsure, seems to adjust lighting color though
+	{ 0x1000000, "ApplyGlobalIllumination" }, // unsure, seems to adjust lighting color though
 	//{ 0x8000000, "InvertShadowFlagBit6" }, // commonModelTrans, seems to invert check for flag 0x40 / bit6
 };
 

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -110,6 +110,12 @@ uint8_t* GameSavePtr()
 	return *g_GameSave_BufPtr;
 }
 
+cManager<cEm>* EmMgr_ptr = nullptr;
+cManager<cEm>* EmMgrPtr()
+{
+	return EmMgr_ptr;
+}
+
 // Original game funcs
 bool(__cdecl* game_KeyOnCheck_0)(KEY_BTN a1);
 void(__cdecl* game_C_MTXOrtho)(Mtx44 mtx, float PosY, float NegY, float NegX, float PosX, float Near, float Far);
@@ -190,6 +196,10 @@ bool Init_Game()
 	// Pointer to the original KeyOnCheck
 	pattern = hook::pattern("E8 ? ? ? ? 83 C4 ? 84 C0 74 ? C7 86 ? ? ? ? ? ? ? ? 5E B8 ? ? ? ? 5B 8B E5 5D C3 53");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), game_KeyOnCheck_0);
+
+	// pointer to EmMgr (instance of cManager<cEm>)
+	pattern = hook::pattern("81 E1 01 02 00 00 83 F9 01 75 ? 50 B9 ? ? ? ? E8");
+	EmMgr_ptr = *pattern.count(1).get(0).get<cManager<cEm>*>(0xD);
 
 	return true;
 }

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -33,14 +33,22 @@ std::unordered_map<int, std::string> UnitBeFlagNames =
 {
 	{ 0x1, "Alive" },
 	{ 0x2, "Trans" },
-	{ 0X10, "CastShadow" },
+	{ 0x8, "AlternateAmbLightColor" }, // checked by LightSetModel, didn't notice any change
+	{ 0x10, "DrawFootShadow" },
 	{ 0x20, "Move" },
-	//{ 0x200, "Alive200" }, // maybe dead flag? setting it seems to set bit10, which unsets a bunch of flags including Alive
-	{ 0x800, "NoSuspend" },
-	{ 0x4000, "DisableAnimation" },
+	{ 0x200, "Dead" }, // maybe dead flag? setting it seems to set Destruct flag, which unsets a bunch of flags including Alive
+	{ 0x400, "Destruct" }, // checked by cManager<cEm>::dieCheck, calls destructor if set
+	{ 0x800, "NoSuspend" }, // keep running even if suspend game flag is set
+	{ 0x1000, "IgnoreDrawDistance" }, // looks like ModelTrans sets distance to 999999 if set
+	{ 0x2000, "ContiguousParts" }, // optimization? checked by cModel::getPartsPtr
+								   // seems to skip following nextParts_F4 pointers and accesses part by index directly if set
+	{ 0x4000, "DisableAnimation" }, // code for this doesn't actually seem anim/motion related, but anims do get disabled by it...
 	{ 0x8000, "DisableLighting" },
 	{ 0x20000, "UseSimpleLighting" },
-	{ 0x1000000, "ColorCorrectLighting" }, // unsure, seems to adjust lighting color though
+	{ 0x100000, "ClothNoScaleApply" }, // PenClothMove3
+	{ 0x200000, "ClothReset" }, // PenClothMove3
+	{ 0x1000000, "UseGlobalIllumination" }, // unsure, seems to adjust lighting color though
+	//{ 0x8000000, "InvertShadowFlagBit6" }, // commonModelTrans, seems to invert check for flag 0x40 / bit6
 };
 
 std::string cEmMgr::EmIdToName(int id)

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -31,11 +31,16 @@ std::unordered_map<int, std::string> EmNames =
 // a lot missing from here sadly ;_;
 std::unordered_map<int, std::string> UnitBeFlagNames =
 {
-	{ 0x1, "Alive1" },
+	{ 0x1, "Alive" },
 	{ 0x2, "Trans" },
+	{ 0X10, "CastShadow" },
 	{ 0x20, "Move" },
-	{ 0x200, "Alive200" },
-	{ 0x800, "NoSuspend" }
+	//{ 0x200, "Alive200" }, // maybe dead flag? setting it seems to set bit10, which unsets a bunch of flags including Alive
+	{ 0x800, "NoSuspend" },
+	{ 0x4000, "DisableAnimation" },
+	{ 0x8000, "DisableLighting" },
+	{ 0x20000, "UseSimpleLighting" },
+	{ 0x1000000, "ColorCorrectLighting" }, // unsure, seems to adjust lighting color though
 };
 
 std::string cEmMgr::EmIdToName(int id)

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -197,7 +197,7 @@ struct EM_LIST
   char set_3;
   uint32_t em_flag_4;
   int16_t hp_8;
-  uint8_t gapA;
+  uint8_t useExtendedParams_A; // normally unused, if set to 1 then our hooks in Trainer.cpp will read from percentage vars below
   char charaId_B;
   int16_t posX_C;
   int16_t posY_E;
@@ -927,6 +927,8 @@ cPlayer* PlayerPtr();
 cPlayer* AshleyPtr();
 uint8_t* GameSavePtr();
 cEmMgr* EmMgrPtr();
+
+bool IsGanado(int id); // same as games IsGanado func
 
 // Length seems to always be 0xFFAA0 across all builds
 #define GAMESAVE_LENGTH 0xFFAA0

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -314,7 +314,7 @@ struct __declspec(align(4)) GLOBALS
   uint8_t field_4FAF;
   uint16_t prevRoomId_4FB0;
   uint8_t field_4FB2;
-  uint8_t field_4FB3;
+  char curEmListNumber_4FB3;
   uint16_t playerHp_4FB4;
   uint16_t playerHpFull_4FB6;
   int16_t ashleyHp_4FB8;
@@ -929,6 +929,7 @@ uint8_t* GameSavePtr();
 cEmMgr* EmMgrPtr();
 
 bool IsGanado(int id); // same as games IsGanado func
+const char* getEmListName(int emListNumber);
 
 // Length seems to always be 0xFFAA0 across all builds
 #define GAMESAVE_LENGTH 0xFFAA0

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -207,7 +207,9 @@ struct EM_LIST
   int16_t rotZ_16;
   int16_t roomId_18;
   int16_t guardRadius_1A;
-  uint8_t gap1C[4];
+  // add some new fields inside normally unused padding, gets read by our Em* hooks in Trainer.cpp
+  uint16_t percentageMotionSpeed_1C;
+  uint16_t percentageScale_1E;
 };
 static_assert(sizeof(EM_LIST) == 0x20, "sizeof(EM_LIST)"); // TODO: find if this size is correct
 
@@ -739,7 +741,7 @@ public:
 	uint8_t unk_396[2];
 	int(__cdecl* emScenarioFn_398)(cEm*);
 	uint8_t unk_39C[4];
-	uint8_t emSetDie_FlagIdx_3A0;
+	uint8_t emListIndex_3A0;
 	uint8_t field_3A1;
 	uint8_t unk_3A2[2];
 	Vec motionMove2Vec_3A4;
@@ -775,6 +777,11 @@ public:
 	inline bool IsValid()
 	{
 		return (be_flag_4 & 0x601) != 0;
+	}
+
+	inline bool IsSpawnedByESL()
+	{
+		return IsValid() && emListIndex_3A0 != 255;
 	}
 
 	int PartCount()

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -523,22 +523,278 @@ struct cPlWep
 };
 static_assert(sizeof(cPlWep) == 0x50, "sizeof(cPlWep)");
 
-struct cPlayer // unsure if correct name!
+class cUnit
 {
-  /* 0x000 */ uint8_t unk0[0x94];
-  /* 0x094 */ float X;
-  /* 0x098 */ float Y;
-  /* 0x09C */ float Z;
-  /* 0x0A0 */ float unkA0;
-  /* 0x0A4 */ float rotation;
-  /* 0x0A8 */ uint8_t unk_A8[0x1D8 - 0xA8];
-  /* 0x1D8 */ MOTION_INFO MotInfo_1D8;
-  /* 0x2A8 */ uint8_t unk_2A8[0x7D8 - 0x2A8];
-  /* 0x7D8 */ cPlWep* plWep_7D8;
-  /* goes to 7F0+ */
+public:
+	uint32_t be_flag_4;
+	cUnit* nextUnit_8;
+
+	virtual ~cUnit() = 0;
+	virtual void beginEvent(uint32_t) = 0;
+	virtual void endEvent(uint32_t) = 0;
+};
+static_assert(sizeof(cUnit) == 0xC, "sizeof(cUnit)");
+
+class cCoord : public cUnit
+{
+public:
+	Mtx mtx_C;
+	Mtx prevMtx_3C;
+	cCoord* parent_6C;
+	Vec field_70;
+	Vec field_7C;
+	Vec field_88;
+	Vec position_94;
+	Vec rotation_A0;
+	Vec scale_AC;
+
+	virtual void matUpdate() = 0;
+};
+static_assert(sizeof(cCoord) == 0xB8, "sizeof(cCoord)");
+
+class cModel;
+
+struct cAtariInfo
+{
+	Vec field_0;
+	float field_C;
+	float field_10;
+	float field_14;
+	int16_t field_18;
+	uint16_t flags_1A;
+	float field_1C;
+	float field_20;
+	int16_t field_24;
+	int16_t field_26;
+	cModel* field_28;
+	float field_2C;
+	uint8_t unk_30[24];
+	cAtariInfo* nextInfo_48;
+};
+static_assert(sizeof(cAtariInfo) == 0x4C, "sizeof(cAtariInfo)");
+
+struct cLightInfo
+{
+	Mtx* field_0;
+	DWORD field_4;
+	DWORD field_8;
+	DWORD field_C;
+	Vec position_10;
+	Vec rotation_1C;
+	Vec scale_28;
+	int32_t field_34;
+	int32_t field_38;
+	int32_t field_3C;
+	int32_t field_40;
+	int32_t field_44;
+	int32_t field_48;
+	int32_t field_4C;
+	uint8_t field_50;
+	uint8_t field_51;
+	uint8_t partNo_52;
+	uint8_t field_53;
+	int32_t field_54;
+	Vec field_58;
+	Vec field_64;
+	float field_70;
+};
+static_assert(sizeof(cLightInfo) == 0x74, "sizeof(cLightInfo)");
+
+class cModel : public cCoord
+{
+public:
+	float field_B8;
+	float field_BC;
+	float field_C0;
+	Mtx mtx_C4;
+	/*cParts* */void* childParts_F4;
+	uint32_t field_F8;
+	uint8_t r_no_0_FC;
+	uint8_t r_no_1_FD;
+	uint8_t r_no_2_FE;
+	uint8_t r_no_3_FF;
+	uint8_t ID_100;
+	uint8_t type_101;
+	uint8_t nParts_102;
+	uint8_t alphaCompareRef_103;
+	Vec speed_104;
+	Vec oldPos_110;
+	Vec field_11C;
+	Vec* field_128;
+	uint8_t unk_12C;
+	uint8_t gxScaleIdx_12D;
+	uint8_t field_12E;
+	uint8_t field_12F;
+	cModel* pCldShMd_130;
+	uint8_t shdCol_134;
+	uint8_t cullMode_135;
+	uint8_t field_136;
+	uint8_t field_137;
+	uint8_t field_138;
+	uint8_t field_139;
+	uint8_t field_13A;
+	uint8_t field_13B;
+	int32_t field_13C;
+	Vec field70_backup_140;
+	int32_t field_14C;
+	int32_t field_150;
+	float deltaTimeRelated_154;
+	float field_158;
+	/*cModelInfo* */ void* pModInfo_15C;
+	/*cModelInfo* */ void* pShMdIfo_160;
+	cLightInfo lightInfo_164;
+	MOTION_INFO MotInfo_1D8;
+	MOTION_INFO* nextMotInfoToBlend_2A8;
+	uint8_t* plMirrorData_2AC;
+	uint32_t* field_2B0;
+	cAtariInfo atariInfo_2B4;
+	int32_t field_300;
+	int32_t field_304;
+	void* fs_tbl_308;
+	int32_t field_30C;
+	int32_t flags_310;
+	int32_t field_314;
+	float field_318;
+	int32_t field_31C;
+	uint8_t field_320;
+	uint8_t field_321;
+	uint8_t field_322;
+	uint8_t field_323;
+
+	virtual void move() = 0;
+	virtual void setNoSuspend(uint32_t) = 0;
+};
+static_assert(sizeof(cModel) == 0x324, "sizeof(cModel)");
+
+struct YARARE_INFO /* yarare: "to suffer damage; to be deceived" */
+{
+	Vec field_0;
+	Vec field_C;
+	float field_18;
+	float field_1C;
+	float field_20;
+	int16_t field_24;
+	int16_t partNo_26;
+	float dmgInfoRelated_28;
+	float field_2C;
+	YARARE_INFO* nextInfo_30;
+};
+
+struct cDmgInfo
+{
+	float field_0;
+	uint8_t field_4;
+	uint8_t field_5;
+	uint8_t wepId_6;
+	uint8_t field_7;
+	Vec field_8;
+	float field_14;
+	YARARE_INFO* yarareInfo_18;
+};
+
+class cEm : public cModel
+{
+public:
+	int16_t HpCur_324;
+	int16_t HpMax_326;
+	cDmgInfo dmgInfo_328;
+	YARARE_INFO yarareInfo_344;
+	float playerDistance_378;
+	float field_37C;
+	void* espDataPtr_380;
+	void* field_384;
+	Vec field_388;
+	char field_394;
+	uint8_t field_395;
+	uint8_t unk_396[2];
+	int(__cdecl* emScenarioFn_398)(cEm*);
+	uint8_t unk_39C[4];
+	uint8_t emSetDie_FlagIdx_3A0;
+	uint8_t field_3A1;
+	uint8_t unk_3A2[2];
+	Vec motionMove2Vec_3A4;
+	Vec field_3B0;
+	float field_3BC;
+	cEm* curInteractingModel_3C0;
+	uint8_t routeCkField_3C4;
+	uint8_t field_3C5[2];
+	uint8_t routeCkField_3C7;
+	uint8_t unk_3C8[1];
+	uint8_t field_3C9;
+	uint8_t unk_3CA[2];
+	uint32_t flags_3CC;
+	uint32_t flags_3D0;
+	float Guard_r_3D4;
+	uint8_t characterNum_3D8;
+	uint8_t field_3D9;
+	uint8_t unk_3DA[4];
+	uint16_t field_3DE;
+	uint16_t field_3E0;
+	uint16_t field_3E2;
+	uint16_t field_3E4;
+	uint8_t unk_3E6[2];
+	uint32_t flags_3E8;
+	Vec field_3EC;
+	Vec field_3F8;
+	int32_t field_404;
+
+	virtual void setItem(int16_t a2, int16_t a3, int16_t a4, int16_t a5, int8_t a6) = 0;
+	virtual void setNoItem() = 0;
+	virtual bool checkThrow() = 0;
+};
+static_assert(sizeof(cEm) == 0x408, "sizeof(cEm)");
+
+class cPlayer : public cEm
+{
+public:
+  uint8_t unk_408[0x7D8 - 0x408];
+  cPlWep* plWep_7D8;
+  uint8_t unk_7DC[0x908 - 0x7DC];
+  /* goes to at least 0x908 */
+
+  virtual void construct2() = 0;
+  virtual int checkXbutton() = 0;
+  virtual int setModel() = 0;
+  virtual void setMotion() = 0;
+  virtual void setRightHand(uint32_t a2) = 0;
+  virtual void setLeftHand(uint32_t a2) = 0;
+  virtual void setFace(uint32_t a2) = 0;
+  virtual void setHead(uint32_t a2, void* a3) = 0;
+  virtual void setHead(DWORD) = 0;
+  virtual void setWound() = 0;
+  virtual void moveMatCalcBefore() = 0;
+  virtual void initCloth() = 0;
+  virtual void moveCloth() = 0;
 };
 #pragma pack(pop)
-static_assert(sizeof(cPlayer) == 0x7DC, "sizeof(cPlayer)"); // TODO: nowhere near the correct size!
+static_assert(sizeof(cPlayer) == 0x908, "sizeof(cPlayer)"); // TODO: need to figure out proper size
+
+template<class T>
+class cManager
+{
+public:
+	T* itemPtr_4;
+	uint32_t itemCount_8;
+	uint32_t itemSize_C;
+	uint8_t unk_10;
+	T* unk_14;
+	uint32_t unk_18;
+
+	T* operator[](uint32_t i)
+	{
+		if (i >= itemCount_8)
+			return nullptr;
+		return (T*)(((uint8_t*)itemPtr_4) + (i * itemSize_C));
+	}
+
+	virtual ~cManager() = 0;
+	virtual void* memAlloc() = 0;
+	virtual void memFree(void* mem) = 0;
+	virtual void memClear(void* mem, size_t size) = 0;
+	virtual void log(int a1, int a2, ...) = 0;
+	virtual void destroy(T* work) = 0;
+	virtual int construct(T* result, uint32_t type) = 0;
+};
 
 struct DatTblEntry
 {
@@ -571,6 +827,7 @@ SYSTEM_SAVE* SystemSavePtr();
 cPlayer* PlayerPtr();
 cPlayer* AshleyPtr();
 uint8_t* GameSavePtr();
+cManager<cEm>* EmMgrPtr();
 
 // Length seems to always be 0xFFAA0 across all builds
 #define GAMESAVE_LENGTH 0xFFAA0

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -727,6 +727,16 @@ struct cDmgInfo
 class cEm : public cModel
 {
 public:
+	enum class Routine0 : uint8_t
+	{
+		// r0 values that are used by pretty much all cEms
+		// (other r* values are usually defined per-cEm though)
+		Init,
+		Move,
+		Damage,
+		Die
+	};
+
 	int16_t HpCur_324;
 	int16_t HpMax_326;
 	cDmgInfo dmgInfo_328;

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -839,27 +839,15 @@ public:
 		return get(i);
 	}
 
-	virtual ~cManager() = 0;
-	virtual void* memAlloc() = 0;
-	virtual void memFree(void* mem) = 0;
-	virtual void memClear(void* mem, size_t size) = 0;
-	virtual void log(int a1, int a2, ...) = 0;
-	virtual void destroy(T* work) = 0;
-	virtual int construct(T* result, uint32_t type) = 0;
-};
-
-// NOTE: valid cEms can be anywhere from itemPtr[0] to itemPtr[maxItemCount], invalid/unused ones can also occur anywhere inside there
-// use cEm::IsValid() to check for validity and skip over invalid cEms if needed
-class cEmMgr : public cManager<cEm>
-{
-public:
+	// iterator is kinda unnecessary.. was going to use it to only iterate through valid items, but found a better way for that instead
+	// the codes already written up now though, not much point in removing it?
 	struct Iterator
 	{
 		using iterator_category = std::forward_iterator_tag;
 		using difference_type = std::ptrdiff_t;
-		using value_type = cEm;
-		using pointer = cEm*;
-		using reference = cEm&;
+		using value_type = T;
+		using pointer = T*;
+		using reference = T&;
 
 		Iterator(pointer ptr, int size) : m_ptr(ptr), m_ptr_size(size) {}
 
@@ -880,12 +868,22 @@ public:
 	Iterator begin() { return Iterator(get(0), itemSize_C); }
 	Iterator end() { return Iterator(get(maxItemCount_8), itemSize_C); }
 	int count() { return maxItemCount_8; }
-	int count_valid() { int i = 0; for (auto& em : *this) if (em.IsValid()) i++; return i; }
 
-	cEm* operator[](uint32_t i)
-	{
-		return get(i);
-	}
+	virtual ~cManager() = 0;
+	virtual void* memAlloc() = 0;
+	virtual void memFree(void* mem) = 0;
+	virtual void memClear(void* mem, size_t size) = 0;
+	virtual void log(int a1, int a2, ...) = 0;
+	virtual void destroy(T* work) = 0;
+	virtual int construct(T* result, uint32_t type) = 0;
+};
+
+// NOTE: valid cEms can be anywhere from itemPtr[0] to itemPtr[maxItemCount], invalid/unused ones can also occur anywhere inside there
+// use cEm::IsValid() to check for validity and skip over invalid cEms if needed
+class cEmMgr : public cManager<cEm>
+{
+public:
+	int count_valid() { int i = 0; for (auto& em : *this) if (em.IsValid()) i++; return i; }
 
 	static std::string EmIdToName(int id);
 };

--- a/dllmain/GameFlags.h
+++ b/dllmain/GameFlags.h
@@ -547,3 +547,12 @@ inline bool FlagIsSet(uint32_t* flagValues, uint32_t flagIndex)
 {
 	return flagValues[(flagIndex / 32)] & (0x80000000 >> (flagIndex & 31));
 }
+
+inline void FlagSet(uint32_t* flagValues, uint32_t flagIndex, bool state)
+{
+	uint32_t flag = (0x80000000 >> (flagIndex & 31));
+	if (state)
+		flagValues[(flagIndex / 32)] |= flag;
+	else
+		flagValues[(flagIndex / 32)] &= ~flag;
+}

--- a/dllmain/MouseTurning.cpp
+++ b/dllmain/MouseTurning.cpp
@@ -63,7 +63,7 @@ void MouseTurn()
 	if (GetMouseAimingMode() == MouseAimingModes::Classic)
 		SpeedMulti = 1300;
 
-	PlayerPtr()->rotation += (-intMouseDeltaX() / SpeedMulti) * pConfig->fTurnSensitivity;
+	PlayerPtr()->rotation_A0.y += (-intMouseDeltaX() / SpeedMulti) * pConfig->fTurnSensitivity;
 }
 
 bool __cdecl KeyOnCheck_hook(KEY_BTN a1)

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -316,6 +316,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->fFontSize = fmin(fmax(pConfig->fFontSize, 1.0f), 1.25f); // limit between 1.0 - 1.25
 
 	pConfig->bDisableMenuTip = iniReader.ReadBoolean("IMGUI", "DisableMenuTip", pConfig->bDisableMenuTip);
+	pConfig->bUseTrainer = iniReader.ReadBoolean("IMGUI", "UseTrainer", pConfig->bUseTrainer);
 
 	// DEBUG
 	pConfig->bVerboseLog = iniReader.ReadBoolean("DEBUG", "VerboseLog", pConfig->bVerboseLog);
@@ -471,6 +472,7 @@ DWORD WINAPI WriteSettingsThread(LPVOID lpParameter)
 
 	// IMGUI
 	iniReader.WriteFloat("IMGUI", "FontSize", pConfig->fFontSize);
+	iniReader.WriteBoolean("IMGUI", "UseTrainer", pConfig->bUseTrainer);
 
 	pConfig->HasUnsavedChanges = false;
 
@@ -620,6 +622,7 @@ void Config::LogSettings()
 	spd::log()->info("+ IMGUI--------------------------+-----------------+");
 	spd::log()->info("| {:<30} | {:>15} |", "FontSize", pConfig->fFontSize);
 	spd::log()->info("| {:<30} | {:>15} |", "DisableMenuTip", pConfig->bDisableMenuTip ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "UseTrainer", pConfig->bUseTrainer ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 
 	// DEBUG

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -118,6 +118,7 @@ public:
 	// IMGUI
 	float fFontSize = 1.0f;
 	bool bDisableMenuTip = false;
+	bool bUseTrainer = false;
 	
 	// DEBUG
 	bool bVerboseLog = false;

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -178,7 +178,7 @@ void __cdecl gameDebug_recreation(void* a1)
 		{
 			cPlayer* pPL = PlayerPtr();
 			if (pPL)
-				eprintf_Hook(32, 300, 0, 0, "[X %7.3f Y %7.3f Z %7.3f R %5.3f]", pPL->X, pPL->Y, pPL->Z, pPL->rotation);
+				eprintf_Hook(32, 300, 0, 0, "[X %7.3f Y %7.3f Z %7.3f R %5.3f]", pPL->position_94.x, pPL->position_94.y, pPL->position_94.z, pPL->rotation_A0.y);
 		}
 	}
 

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -261,6 +261,14 @@ void ToolMenu_Exit()
 
 void ToolMenu_GoldMax()
 {
+	auto& emMgr = *EmMgrPtr();
+	for (uint32_t i = 0; i < emMgr.itemCount_8; i++)
+	{
+		cEm* item = emMgr[i];
+		// TODO: filter based on item->ID_100
+		item->MotInfo_1D8.speed_C0 *= 2;
+	}
+
 	GlobalPtr()->money_4FA8 = 99999999;
 
 	ToolMenu_Exit();

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -444,10 +444,6 @@ void Init_ToolMenu()
 		pattern = hook::pattern("53 E8 ? ? ? ? 8D 4D FC 51 8D 55 F8");
 		InjectHook(pattern.count(1).get(0).get<uint32_t>(1), gameDebug_recreation);
 
-		// Remove bzero call that clears flags every frame for some reason
-		pattern = hook::pattern("83 C0 60 6A 10 50 E8");
-		injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(6), 5, true);
-
 		// Hook eprintf to add screen-drawing to it, like the GC debug has
 		// (required for debug-menu to be able to draw itself)
 		pattern = hook::pattern("55 8B EC 8B 4D ? 8D 45 ? 50 51 68 ? ? ? ? E8 ? ? ? ? 83 C4 ? 5D C3");

--- a/dllmain/ToolMenu.cpp
+++ b/dllmain/ToolMenu.cpp
@@ -261,14 +261,6 @@ void ToolMenu_Exit()
 
 void ToolMenu_GoldMax()
 {
-	auto& emMgr = *EmMgrPtr();
-	for (uint32_t i = 0; i < emMgr.itemCount_8; i++)
-	{
-		cEm* item = emMgr[i];
-		// TODO: filter based on item->ID_100
-		item->MotInfo_1D8.speed_C0 *= 2;
-	}
-
 	GlobalPtr()->money_4FA8 = 99999999;
 
 	ToolMenu_Exit();

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -103,6 +103,21 @@ void Trainer_Init()
 		patch_LifeDownSet2.SetPatch(LifeDownSet2_jg, { 0x90, 0x90 });
 		flagPatches.push_back(patch_LifeDownSet2);
 	}
+
+	// DBG_INF_BULLET
+	{
+		auto pattern = hook::pattern("0B D1 66 89 57 08");
+		auto cItemMgr__trigger_0_mov = pattern.count(1).get(0).get<uint8_t>(2);
+		FlagPatch patch_cItemMgr__trigger_0(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_INF_BULLET));
+		patch_cItemMgr__trigger_0.SetPatch(cItemMgr__trigger_0_mov, { 0x90, 0x90, 0x90, 0x90 });
+		flagPatches.push_back(patch_cItemMgr__trigger_0);
+
+		pattern = hook::pattern("4A 66 89 50 02");
+		auto cItemMgr__dump_0_mov = pattern.count(1).get(0).get<uint8_t>(1);
+		FlagPatch patch_cItemMgr__dump_0(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_INF_BULLET));
+		patch_cItemMgr__dump_0.SetPatch(cItemMgr__dump_0_mov, { 0x90, 0x90, 0x90, 0x90 });
+		flagPatches.push_back(patch_cItemMgr__dump_0);
+	}
 }
 
 void Trainer_Update()

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -57,21 +57,10 @@ struct FlagPatch
 
 std::vector<FlagPatch> flagPatches;
 
-bool IsGanado(int id) // same as games IsGanado func
-{
-	if (id == 0x4B || id == 0x4E)
-		return 0;
-	if ((unsigned int)(id - 0x40) <= 0xF)
-		return 1;
-	if (id < 0x10)
-		return 0;
-	return id <= 0x20;
-}
-
 void SetEmListParamExtensions(cEm* em, EM_LIST* emData)
 {
-	//emData->percentageMotionSpeed_1C = 400;
-	//emData->percentageScale_1E = 400;
+	if (emData->useExtendedParams_A != 1)
+		return;
 
 	if (emData->percentageMotionSpeed_1C)
 		em->MotInfo_1D8.speed_C0 = float(double(emData->percentageMotionSpeed_1C) / 100.0f);

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -93,6 +93,16 @@ void Trainer_Init()
 		patch_PlGachaMove.SetPatch(PlGachaMove, { 0xC3 });
 		flagPatches.push_back(patch_PlGachaMove);
 	}
+
+	// DBG_EM_WEAK
+	{
+		// LifeDownSet2 patch
+		auto pattern = hook::pattern("0F BF 86 24 03 00 00 3B C7 7D");
+		auto LifeDownSet2_jg = pattern.count(1).get(0).get<uint8_t>(9);
+		FlagPatch patch_LifeDownSet2(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_EM_WEAK));
+		patch_LifeDownSet2.SetPatch(LifeDownSet2_jg, { 0x90, 0x90 });
+		flagPatches.push_back(patch_LifeDownSet2);
+	}
 }
 
 void Trainer_Update()

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -59,6 +59,13 @@ std::vector<FlagPatch> flagPatches;
 
 void SetEmListParamExtensions(cEm* em, EM_LIST* emData)
 {
+	// Game sometimes uses hardcoded stack-based EM_LIST to spawn certain enemies
+	// In those cases, 0xA & 0x1C usually are left untouched, resulting in random stack data being used
+	// To protect against that, we'll only allow param extensions from emData that came from pG->emList_5410
+	GLOBALS* pG = GlobalPtr();
+	if (emData < pG->emList_5410 || emData >= &pG->emList_5410[256])
+		return;
+
 	if (emData->useExtendedParams_A != 1)
 		return;
 
@@ -74,7 +81,7 @@ void SetEmListParamExtensions(cEm* em, EM_LIST* emData)
 		{
 			// cEm10 holds a seperate scale value that it seems to grow/shrink the actual scale towards each frame
 			// make sure we update that as well
-			Vec* scale_bk_498 = (Vec*)(((uint8_t*)em) + 0x498);
+			Vec* scale_bk_498 = (Vec*)((uint8_t*)em + 0x498);
 			*scale_bk_498 = em->scale_AC;
 		}
 	}

--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -1,0 +1,104 @@
+#include <iostream>
+#include "dllmain.h"
+#include "Game.h"
+#include "Settings.h"
+
+// Trainer.cpp: checks certain game flags & patches code in response to them
+// Ideally we would hook each piece of code instead and add a flag check there
+// Unfortunately, most existing trainer-like-mods for the game are done as code patches
+// So to make it easier on us, this will act as a manager to tie code patches with game flags
+// (maybe over time these patches can be converted to work as hooks instead)
+
+// Holds data about a patch, which flag it should be affected by, address to patch, undo data...
+struct FlagPatch
+{
+	uint32_t* flagValuesPtr;
+	uint32_t flagIndex;
+	uint8_t* patchAddress;
+	std::vector<uint8_t> patchData;
+
+	bool prevFlagValue = false;
+	std::vector<uint8_t> origData;
+
+	FlagPatch(uint32_t* FlagValuesPtr, uint32_t FlagIndex) : flagValuesPtr(FlagValuesPtr), flagIndex(FlagIndex) {}
+
+	void SetPatch(uint8_t* address, std::initializer_list<uint8_t> data)
+	{
+		patchAddress = address;
+		patchData = data;
+
+		if (!patchData.size())
+			return;
+		origData.resize(patchData.size());
+		memcpy(origData.data(), patchAddress, patchData.size());
+	}
+
+	void Update()
+	{
+		bool value = CurValue();
+		if(value == prevFlagValue)
+			return; // flag not changed, no need to do anything
+
+		auto& data = value ? patchData : origData;
+		DWORD		dwProtect;
+		VirtualProtect((void*)patchAddress, data.size(), PAGE_EXECUTE_READWRITE, &dwProtect);
+		memcpy(patchAddress, data.data(), data.size());
+		VirtualProtect((void*)patchAddress, data.size(), dwProtect, &dwProtect);
+
+		prevFlagValue = value;
+	}
+
+	bool CurValue()
+	{
+		return FlagIsSet(flagValuesPtr, flagIndex);
+	}
+
+};
+
+std::vector<FlagPatch> flagPatches;
+
+void Trainer_Init()
+{
+	GLOBALS* globals = GlobalPtr();
+	if (!globals)
+		return;
+
+	// DBG_PL_NOHIT
+	{
+		// EmAtkHitCk patch
+		auto pattern = hook::pattern("05 88 00 00 00 50 53 57 E8");
+		auto EmAtkHitCk_thunk = injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(8));
+		FlagPatch patch_EmAtkHitCk(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+		patch_EmAtkHitCk.SetPatch((uint8_t*)EmAtkHitCk_thunk.as_int(), {0x33, 0xC0, 0xC3});
+		flagPatches.push_back(patch_EmAtkHitCk);
+
+		// LifeDownSet2 patch
+		pattern = hook::pattern("0F 85 ? ? ? ? A1 ? ? ? ? 66 83 B8 B4 4F 00 00 00 7F");
+		auto LifeDownSet2_jg = pattern.count(1).get(0).get<uint8_t>(0x13);
+		FlagPatch patch_LifeDownSet2(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+		patch_LifeDownSet2.SetPatch(LifeDownSet2_jg, { 0x90, 0x90 });
+		flagPatches.push_back(patch_LifeDownSet2);
+
+		// PlGachaGet patch
+		pattern = hook::pattern("A1 ? ? ? ? 8B 15 ? ? ? ? 80 BA 98 4F 00 00 03");
+		auto PlGachaGet = pattern.count(1).get(0).get<uint8_t>(0);
+		FlagPatch patch_PlGachaGet(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+		patch_PlGachaGet.SetPatch(PlGachaGet, { 0xB8, 0x7F, 0x00, 0x00, 0x00, 0xC3 });
+		flagPatches.push_back(patch_PlGachaGet);
+
+		// PlGachaMove patch (prevents button prompt when grabbed)
+		pattern = hook::pattern("57 8B 3D ? ? ? ? 6A 00 6A 00 6A 11 6A 0B");
+		auto PlGachaMove = pattern.count(1).get(0).get<uint8_t>(0);
+		FlagPatch patch_PlGachaMove(globals->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+		patch_PlGachaMove.SetPatch(PlGachaMove, { 0xC3 });
+		flagPatches.push_back(patch_PlGachaMove);
+	}
+}
+
+void Trainer_Update()
+{
+	for (auto& flagPatch : flagPatches)
+	{
+		flagPatch.Update();
+	}
+}

--- a/dllmain/Trainer.h
+++ b/dllmain/Trainer.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void Trainer_Init();
+void Trainer_Update();

--- a/dllmain/Trainer.h
+++ b/dllmain/Trainer.h
@@ -2,3 +2,6 @@
 
 void Trainer_Init();
 void Trainer_Update();
+
+extern bool bUseNumpadMovement;
+extern bool bUseMouseWheelUPDOWN;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1735,6 +1735,7 @@ void cfgMenuRender()
 						ImGui_ColumnInit();
 
 						static bool onlyShowValidEms = true;
+						static bool onlyShowESLSpawned = false;
 #ifdef _DEBUG
 						static bool showEmPointers = true;
 #else
@@ -1747,6 +1748,8 @@ void cfgMenuRender()
 							ImGui_ColumnSwitch();
 
 							ImGui::Text("Em Count: %d | Max: %d", emMgr.count_valid(), emMgr.count());
+							ImGui::SameLine();
+							ImGui::Checkbox("ESL-spawned only", &onlyShowESLSpawned);
 
 							if (ImGui::BeginListBox("", ImVec2(320, 420)))
 							{
@@ -1755,17 +1758,20 @@ void cfgMenuRender()
 								{
 									if (!onlyShowValidEms || em.IsValid())
 									{
-										char tmpBuf[256];
-										if (showEmPointers)
-											sprintf(tmpBuf, "#%d:0x%x c%s (type %x) flags %x", i, (uint32_t)&em, cEmMgr::EmIdToName(em.ID_100).c_str(), int(em.type_101), int(em.be_flag_4));
-										else
-											sprintf(tmpBuf, "#%d c%s (type %x) flags %x", i, cEmMgr::EmIdToName(em.ID_100).c_str(), int(em.type_101), int(em.be_flag_4));
-										const bool is_selected = (emIdx == i);
-										if (ImGui::Selectable(tmpBuf, is_selected))
-											emIdx = i;
-										// Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
-										if (is_selected)
-											ImGui::SetItemDefaultFocus();
+										if (!onlyShowESLSpawned || em.IsSpawnedByESL())
+										{
+											char tmpBuf[256];
+											if (showEmPointers)
+												sprintf(tmpBuf, "#%d:0x%x c%s (type %x) flags %x", i, (uint32_t)&em, cEmMgr::EmIdToName(em.ID_100).c_str(), int(em.type_101), int(em.be_flag_4));
+											else
+												sprintf(tmpBuf, "#%d c%s (type %x) flags %x", i, cEmMgr::EmIdToName(em.ID_100).c_str(), int(em.type_101), int(em.be_flag_4));
+											const bool is_selected = (emIdx == i);
+											if (ImGui::Selectable(tmpBuf, is_selected))
+												emIdx = i;
+											// Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
+											if (is_selected)
+												ImGui::SetItemDefaultFocus();
+										}
 									}
 
 									i++;
@@ -1899,6 +1905,8 @@ void cfgMenuRender()
 										em->HpMax_326 = hpMax;
 
 									ImGui::Text("Parts count: %d", em->PartCount());
+									if (em->emListIndex_3A0 != 255)
+										ImGui::Text("ESL index: %d (offset 0x%x)", int(em->emListIndex_3A0), int(em->emListIndex_3A0) * 0x20);
 
 									ImGui::Dummy(ImVec2(10, 25));
 

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1659,6 +1659,12 @@ void cfgMenuRender()
 						if (ImGui::Checkbox("Invincible", &invincibility))
 							FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), invincibility);
 
+						ImGui::SameLine();
+
+						bool weakEnemies = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_EM_WEAK));
+						if (ImGui::Checkbox("1-Shot Enemies", &weakEnemies))
+							FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_EM_WEAK), weakEnemies);
+
 						ImGui::Text("cEmMgr");
 						ImGui::Text("Count: %d | Max: %d", emMgr.count_valid(), emMgr.count());
 

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1693,9 +1693,9 @@ void cfgMenuRender()
 						// Invincibility
 						{
 							ImGui_ColumnSwitch();
-							bool invincibility = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+							bool invincibility = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_NO_DEATH));
 							if (ImGui::Checkbox("Invincibility", &invincibility))
-								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), invincibility);
+								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_NO_DEATH), invincibility);
 
 							ImGui::TextWrapped("Prevents taking hits from enemies & automatically skips grabs.");
 						}
@@ -1720,6 +1720,17 @@ void cfgMenuRender()
 								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_INF_BULLET), infAmmo);
 
 							ImGui::TextWrapped("Prevents game from removing bullets after firing.");
+						}
+
+						// Keypad Movement
+						{
+							ImGui_ColumnSwitch();
+
+							bool keypadMovement = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+							if (ImGui::Checkbox("Keypad Movement", &keypadMovement))
+								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), keypadMovement);
+
+							ImGui::TextWrapped("Allows noclip-style movement via keypad.");
 						}
 
 						ImGui_ColumnFinish();
@@ -1749,7 +1760,7 @@ void cfgMenuRender()
 
 							ImGui::Text("Em Count: %d | Max: %d", emMgr.count_valid(), emMgr.count());
 							ImGui::SameLine();
-							ImGui::Checkbox("ESL-spawned only", &onlyShowESLSpawned);
+							ImGui::Checkbox("Show addresses", &showEmPointers);
 
 							if (ImGui::BeginListBox("", ImVec2(320, 420)))
 							{
@@ -1779,8 +1790,8 @@ void cfgMenuRender()
 								ImGui::EndListBox();
 							}
 
-							ImGui::Checkbox("Show addresses", &showEmPointers); ImGui::SameLine();
-							ImGui::Checkbox("Active instances only", &onlyShowValidEms);
+							ImGui::Checkbox("Active", &onlyShowValidEms); ImGui::SameLine();
+							ImGui::Checkbox("ESL-spawned", &onlyShowESLSpawned);
 						}
 
 						// cEm info
@@ -1913,6 +1924,7 @@ void cfgMenuRender()
 									if (ImGui::InputInt("HpMax", &hpMax, 1, 100, ImGuiInputTextFlags_EnterReturnsTrue))
 										em->HpMax_326 = hpMax;
 
+									ImGui::Text("Routine: %02X %02X %02X %02X", em->r_no_0_FC, em->r_no_1_FD, em->r_no_2_FE, em->r_no_3_FF);
 									ImGui::Text("Parts count: %d", em->PartCount());
 									if (em->emListIndex_3A0 != 255)
 										ImGui::Text("ESL: %s @ #%d (offset 0x%x)", getEmListName(GlobalPtr()->curEmListNumber_4FB3), int(em->emListIndex_3A0), int(em->emListIndex_3A0) * sizeof(EM_LIST));

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1654,6 +1654,11 @@ void cfgMenuRender()
 					// cEm list
 					{
 						ImGui_ColumnSwitch();
+
+						bool invincibility = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+						if (ImGui::Checkbox("Invincible", &invincibility))
+							FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), invincibility);
+
 						ImGui::Text("cEmMgr");
 						ImGui::Text("Count: %d | Max: %d", emMgr.count_valid(), emMgr.count());
 
@@ -1703,34 +1708,19 @@ void cfgMenuRender()
 
 								ImGui::SameLine();
 
-								// hacky way of restoring atariinfo flags after game has had a chance to run cEmXX::move
-								static uint16_t atariFlagBackup = 0;
-								static bool atariFlagBackupSet = false;
-								if (atariFlagBackupSet)
-								{
-									em->atariInfo_2B4.flags_1A = atariFlagBackup;
-									atariFlagBackupSet = false;
-								}
 								if (ImGui::Button("Paste position"))
 								{
 									em->position_94 = copyPosition;
 									em->oldPos_110 = copyPosition;
 
-									// disable collision, until next frame restores it
-									atariFlagBackup = em->atariInfo_2B4.flags_1A;
-									atariFlagBackupSet = true;
-
-									em->atariInfo_2B4.flags_1A &= ~0x100;
+									// temporarily disable atariInfo collision, prevents colliding with map
+									uint16_t flagBackup = em->atariInfo_2B4.flags_1A;
+									em->atariInfo_2B4.flags_1A = 0;
 
 									em->matUpdate();
-								}
+									em->move();
 
-								static uint16_t playerAtariFlagBackup = 0;
-								static bool playerAtariFlagBackupSet = false;
-								if (playerAtariFlagBackupSet)
-								{
-									PlayerPtr()->atariInfo_2B4.flags_1A = playerAtariFlagBackup;
-									playerAtariFlagBackupSet = false;
+									em->atariInfo_2B4.flags_1A = flagBackup;
 								}
 
 								cPlayer* player = PlayerPtr();
@@ -1741,11 +1731,14 @@ void cfgMenuRender()
 										player->position_94 = em->position_94;
 										player->oldPos_110 = em->position_94;
 
-										playerAtariFlagBackup = player->atariInfo_2B4.flags_1A;
-										playerAtariFlagBackupSet = true;
+										// temporarily disable atariInfo collision, prevents colliding with map
+										uint16_t flagBackup = player->atariInfo_2B4.flags_1A;
+										player->atariInfo_2B4.flags_1A = 0;
 
-										player->atariInfo_2B4.flags_1A &= ~0x100;
 										player->matUpdate();
+										player->move();
+
+										player->atariInfo_2B4.flags_1A = flagBackup;
 									}
 								}
 

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -9,6 +9,7 @@
 #include "Patches.h"
 #include <hashes.h>
 #include "Utils.h"
+#include "Trainer.h"
 
 bool bCfgMenuOpen;
 bool NeedsToRestart;
@@ -1726,11 +1727,23 @@ void cfgMenuRender()
 						{
 							ImGui_ColumnSwitch();
 
-							bool numpadMovement = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
-							if (ImGui::Checkbox("Numpad Movement", &numpadMovement))
-								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), numpadMovement);
+							bool DisablePlayerCollision = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+							if (ImGui::Checkbox("Disable Player Collision", &DisablePlayerCollision))
+								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), DisablePlayerCollision);
 
-							ImGui::TextWrapped("Allows noclip-style movement via numpad.");
+							ImGui::TextWrapped("Disables collision (no-clip).");
+
+							ImGui::Spacing();
+
+							ImGui::BeginDisabled(!DisablePlayerCollision);
+							ImGui::Checkbox("Numpad Movement", &bUseNumpadMovement);
+							ImGui::TextWrapped("Allows noclip movement via numpad.");
+
+							ImGui::Spacing();
+
+							ImGui::Checkbox("Use Mouse Wheel", &bUseMouseWheelUPDOWN);
+							ImGui::TextWrapped("Allows using the mouse wheel to go up and down.");
+							ImGui::EndDisabled();
 						}
 
 						ImGui_ColumnFinish();

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1892,7 +1892,16 @@ void cfgMenuRender()
 										em->matUpdate();
 
 									if (ImGui::InputFloat3("Scale", (float*)&em->scale_AC, "%.3f", ImGuiInputTextFlags_EnterReturnsTrue))
+									{
+										if (IsGanado(em->ID_100))
+										{
+											// cEm10 holds a seperate scale value that it seems to grow/shrink the actual scale towards each frame
+											// make sure we update that as well
+											Vec* scale_bk_498 = (Vec*)(((uint8_t*)em) + 0x498);
+											*scale_bk_498 = em->scale_AC;
+										}
 										em->matUpdate();
+									}
 
 									ImGui::InputFloat("MotInfo.Speed", &em->MotInfo_1D8.speed_C0, 0.1f);
 

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1693,9 +1693,9 @@ void cfgMenuRender()
 						// Invincibility
 						{
 							ImGui_ColumnSwitch();
-							bool invincibility = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_NO_DEATH));
+							bool invincibility = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_NO_DEATH2));
 							if (ImGui::Checkbox("Invincibility", &invincibility))
-								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_NO_DEATH), invincibility);
+								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_NO_DEATH2), invincibility);
 
 							ImGui::TextWrapped("Prevents taking hits from enemies & automatically skips grabs.");
 						}
@@ -1722,15 +1722,15 @@ void cfgMenuRender()
 							ImGui::TextWrapped("Prevents game from removing bullets after firing.");
 						}
 
-						// Keypad Movement
+						// Numpad Movement
 						{
 							ImGui_ColumnSwitch();
 
-							bool keypadMovement = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
-							if (ImGui::Checkbox("Keypad Movement", &keypadMovement))
-								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), keypadMovement);
+							bool numpadMovement = FlagIsSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT));
+							if (ImGui::Checkbox("Numpad Movement", &numpadMovement))
+								FlagSet(GlobalPtr()->flags_DEBUG_60, uint32_t(Flags_DEBUG::DBG_PL_NOHIT), numpadMovement);
 
-							ImGui::TextWrapped("Allows noclip-style movement via keypad.");
+							ImGui::TextWrapped("Allows noclip-style movement via numpad.");
 						}
 
 						ImGui_ColumnFinish();

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -98,7 +98,7 @@ bool ImGui_TabButton(const char* btnID, const char* text, const ImVec4& activeCo
 	auto p0 = ImGui::GetItemRectMin();
 	auto p1 = ImGui::GetItemRectMax();
 	drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(p0.x + 35.0f, p0.y + 10.0f), iconColor, icon, NULL, 0.0f, &ImVec4(p0.x, p0.y, p1.x, p1.y));
-	drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(p0.x + 65.0f, p0.y + 8.0f), IM_COL32_WHITE, text, NULL, 0.0f, &ImVec4(p0.x, p0.y, p1.x, p1.y));
+	drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(p0.x + 65.0f, p0.y + 8.0f), textColor, text, NULL, 0.0f, &ImVec4(p0.x, p0.y, p1.x, p1.y));
 
 	if (ret)
 		Tab = tabID;
@@ -119,7 +119,7 @@ bool ImGui_TrainerTabButton(const char* btnID, const char* text, const ImVec4& a
 	auto p0 = ImGui::GetItemRectMin();
 	auto p1 = ImGui::GetItemRectMax();
 	drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(p0.x + 35.0f, p0.y + 10.0f), iconColor, icon, NULL, 0.0f, &ImVec4(p0.x, p0.y, p1.x, p1.y));
-	drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(p0.x + 65.0f, p0.y + 8.0f), IM_COL32_WHITE, text, NULL, 0.0f, &ImVec4(p0.x, p0.y, p1.x, p1.y));
+	drawList->AddText(ImGui::GetFont(), ImGui::GetFontSize(), ImVec2(p0.x + 65.0f, p0.y + 8.0f), textColor, text, NULL, 0.0f, &ImVec4(p0.x, p0.y, p1.x, p1.y));
 
 	if (ret)
 		CurTrainerTab = tabID;
@@ -244,8 +244,8 @@ void cfgMenuRender()
 
 			ImColor icn_color = ImColor(230, 15, 95);
 
-			ImVec4 active = ImVec4(150.0f / 255.0f, 10.0f / 255.0f, 40.0f / 255.0f, 255.0f / 255.0f);
-			ImVec4 inactive = ImVec4(31.0f / 255.0f, 30.0f / 255.0f, 31.0f / 255.0f, 0.0f / 255.0f);
+			ImColor active = ImColor(150, 10, 40, 255);
+			ImColor inactive = ImColor(31, 30, 31, 0);
 
 			// cfgMenu title
 			ImGui::SetCursorPos(ImVec2(12, 25));
@@ -301,7 +301,47 @@ void cfgMenuRender()
 
 			// Trainer
 			ImGui::Dummy(ImVec2(0, 13)); ImGui::SameLine();
-			ImGui_TabButton("##trainer", "Trainer", active, inactive, MenuTab::Trainer, ICON_FA_SHOE_PRINTS, icn_color, IM_COL32_WHITE, ImVec2(172, 31));
+
+			if (!pConfig->bUseTrainer)
+			{
+				if (ImGui_TabButton("##trainer", "Trainer", active, inactive, MenuTab::Trainer, ICON_FA_SHOE_PRINTS, ImColor(255, 255, 255, 60), ImColor(255, 255, 255, 60), ImVec2(172, 31)))
+					ImGui::OpenPopup("Trainer menu");
+
+				// Always center this window when appearing
+				ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+				ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+				if (ImGui::BeginPopupModal("Trainer menu", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+				{
+					ImGui::Text("Warning: this section contains cheats & patches that may ruin your game experience,\nor break things in the game.\n\nAre you sure you want to use the trainer menu?\n\n");
+					ImGui::Separator();
+
+					ImGui::SetCursorPos(ImVec2(ImGui::GetWindowWidth() - 265, ImGui::GetCursorPos().y));
+					ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.51f, 0.00f, 0.14f, 1.00f));
+
+					if (ImGui::Button("Yes", ImVec2(120, 0)))
+					{ 
+						pConfig->bUseTrainer = true;
+						pConfig->WriteSettings();
+						ImGui::CloseCurrentPopup();
+					}
+
+					ImGui::SetItemDefaultFocus();
+					ImGui::SameLine();
+
+					if (ImGui::Button("Cancel", ImVec2(120, 0))) 
+					{ 
+						Tab = MenuTab::Display;
+						ImGui::CloseCurrentPopup(); 
+					}
+
+					ImGui::PopStyleColor();
+					ImGui::EndPopup();
+				}
+			
+			}
+			else
+				ImGui_TabButton("##trainer", "Trainer", active, inactive, MenuTab::Trainer, ICON_FA_SHOE_PRINTS, icn_color, IM_COL32_WHITE, ImVec2(172, 31));
 
 			ImGui::Dummy(ImVec2(0.0f, 12.0f));
 
@@ -1670,8 +1710,8 @@ void cfgMenuRender()
 			{
 				ImColor icn_color = ImColor(230, 15, 95);
 
-				ImVec4 active = ImVec4(150.0f / 255.0f, 10.0f / 255.0f, 40.0f / 255.0f, 255.0f / 255.0f);
-				ImVec4 inactive = ImVec4(31.0f / 255.0f, 30.0f / 255.0f, 31.0f / 255.0f, 0.0f / 255.0f);
+				ImColor active = ImColor(150, 10, 40, 255);
+				ImColor inactive = ImColor(31, 30, 31, 0);
 
 				// Patches
 				ImGui_TrainerTabButton("##patches", "Patches", active, inactive, TrainerTab::Patches, ICON_FA_DESKTOP, icn_color, IM_COL32_WHITE, ImVec2(172, 31));

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1897,7 +1897,7 @@ void cfgMenuRender()
 										{
 											// cEm10 holds a seperate scale value that it seems to grow/shrink the actual scale towards each frame
 											// make sure we update that as well
-											Vec* scale_bk_498 = (Vec*)(((uint8_t*)em) + 0x498);
+											Vec* scale_bk_498 = (Vec*)((uint8_t*)em + 0x498);
 											*scale_bk_498 = em->scale_AC;
 										}
 										em->matUpdate();
@@ -1915,7 +1915,7 @@ void cfgMenuRender()
 
 									ImGui::Text("Parts count: %d", em->PartCount());
 									if (em->emListIndex_3A0 != 255)
-										ImGui::Text("ESL index: %d (offset 0x%x)", int(em->emListIndex_3A0), int(em->emListIndex_3A0) * 0x20);
+										ImGui::Text("ESL: %s @ #%d (offset 0x%x)", getEmListName(GlobalPtr()->curEmListNumber_4FB3), int(em->emListIndex_3A0), int(em->emListIndex_3A0) * sizeof(EM_LIST));
 
 									ImGui::Dummy(ImVec2(10, 25));
 

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -7,6 +7,7 @@
 #include "input.hpp"
 #include "gitparams.h"
 #include "resource.h"
+#include "Trainer.h"
 
 std::string WrapperMode;
 std::string WrapperName;
@@ -88,6 +89,8 @@ void Init_Main()
 		Init_HDProject();
 
 	Init_ExceptionHandler();
+
+	Trainer_Init();
 }
 
 void StorePath(HMODULE hModule)

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -149,6 +149,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     <ClCompile Include="Settings.cpp" />
     <ClCompile Include="Sofdec.cpp" />
     <ClCompile Include="FilterXXFixes.cpp" />
+    <ClCompile Include="Trainer.cpp" />
     <ClCompile Include="AspectRatioTweaks.cpp" />
     <ClCompile Include="Utils.cpp" />
     <ClCompile Include="WndProcHook.cpp" />
@@ -224,6 +225,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     <ClInclude Include="Patches.h" />
     <ClInclude Include="Settings.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="Trainer.h" />
     <ClInclude Include="Utils.h" />
   </ItemGroup>
   <ItemGroup>

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClCompile Include="HDProject.cpp">
       <Filter>dllmain</Filter>
     </ClCompile>
+    <ClCompile Include="Trainer.cpp">
+      <Filter>dllmain</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\external\inireader\ini_parser.hpp">
@@ -340,6 +343,9 @@
       <Filter>dllmain</Filter>
     </ClInclude>
     <ClInclude Include="dllmain.h">
+      <Filter>dllmain</Filter>
+    </ClInclude>
+    <ClInclude Include="Trainer.h">
       <Filter>dllmain</Filter>
     </ClInclude>
   </ItemGroup>

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -311,6 +311,9 @@ FontSize = 1.000
 ; Disables the "Press key to open the configuration menu" tooltip.
 DisableMenuTip = false
 
+; Allows the use of the "Trainer" tab
+UseTrainer = false
+
 [DEBUG]
 ; Logs extra information.
 VerboseLog = false


### PR DESCRIPTION
As mentioned at https://github.com/nipkownix/re4_tweaks/issues/243#issuecomment-1181395554

Added a quick GUI for editing data of `cEm` instances, also added some trainer patches to it as well, currently includes an Invincibility patch & a 1-shot-kill weak enemies patch - both patches are linked up to debug flags so the tool menu flag editor should be able to enable them too (maybe in future we could add a way to bind certain flags to hotkeys too, or something like that)

E: also added a infinite ammo patch, thanks to @Mister-Curious for providing the bytes for it!

![bio4_22-07-12_17-22-59](https://user-images.githubusercontent.com/1755499/178543667-8756ef6d-e32c-4e1d-8e8a-12534fb58782.png)

**This is currently a draft PR since we're still waiting on #257 to be tested**/merged, which this includes some of the GUI changes from, once that's merged I'll probably redo this branch again.

Only really tested with 1.1.0 so far, but everything is sig scanned etc, so hopefully should work on other versions too.

Also interested in any requests for things to add to this section, or any ideas on best way to save/load `cEm` changes, not really sure how to handle that atm.
(main issue is that there's no way to uniquely ID a cEm... afaik cEms can get loaded into any slot, so can't rely on the index of it to know where to load modded values into, also cEms can be created/destroyed any time during play, so the cEm being changed might not even exist when level is loaded)