### PR TITLE
bug_report.yaml: update links for HDProject 1.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Let us know about bugs found with the game / tweaks
+description: Let us know about bugs found with the game/tweaks
 labels: bug
 body:
   - id: disclaimer
@@ -18,9 +18,9 @@ body:
     attributes:
       label: Validation
       options:
-      - label: "Game has been updated to the latest RE4HD release (v1.0.1: https://www.re4hd.com/?p=9471)"
+      - label: "Game has been updated to the latest RE4HD release (v1.1: https://www.re4hd.com/?p=9552)"
         required: true
-      - label: "Data has been [validated with SFV](https://www.re4hd.com/?p=9454) (a guide to using QuickSFV is available at that link, use that with this 1.0.1 SFV: [BIO4-HDProject1.0.1-SFV.zip](https://github.com/nipkownix/re4_tweaks/files/8057899/BIO4-HDProject1.0.1-SFV.zip))"
+      - label: "Data has been [validated with SFV](https://www.re4hd.com/?p=9454) (a guide to using QuickSFV is available at that link, use that with this 1.1 SFV: [BIO4-HDProject1.1-SFV.zip](https://github.com/emoose/re4-research/files/9207370/BIO4-HDProject1.1-SFV.zip))"
         required: true
   - id: problem
     type: textarea


### PR DESCRIPTION
Included a link to the BIO4.sfv that came with 1.1, since I'm not sure whether that SFV is included in the update-only release.

E: ugh it got made as a draft PR again, should be fixed I think