### PR TITLE
LAApatch: prompt user before game window is created or any textures loaded

### DIFF
--- a/dllmain/EndSceneHook.cpp
+++ b/dllmain/EndSceneHook.cpp
@@ -280,14 +280,7 @@ void EndSceneHook::EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 	#ifdef VERBOSE
 	// Show the console if in verbose
 	con.ShowConsoleOutput();
-	#endif 
-
-	// Show the LAA window if needed
-	if (laa.LAA_State != LAADialogState::NotShowing)
-	{
-		if ((esHook._last_present_time - esHook._start_time) > std::chrono::seconds(10))
-			laa.LAARender();
-	}
+	#endif
 
 	// Show the cfgMenu
 	if (bCfgMenuOpen)
@@ -297,15 +290,15 @@ void EndSceneHook::EndScene_hook(LPDIRECT3DDEVICE9 pDevice)
 	}
 
 	// Show cursor if needed
-	ImGui::GetIO().MouseDrawCursor = bCfgMenuOpen || (laa.LAA_State != LAADialogState::NotShowing);
+	ImGui::GetIO().MouseDrawCursor = bCfgMenuOpen;
 
 	ImGui::EndFrame();
 	ImGui::Render();
 
 	ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
 
-	pInput->block_mouse_input(bCfgMenuOpen || (laa.LAA_State != LAADialogState::NotShowing));
-	pInput->block_keyboard_input(bCfgMenuOpen || (laa.LAA_State != LAADialogState::NotShowing));
+	pInput->block_mouse_input(bCfgMenuOpen);
+	pInput->block_keyboard_input(bCfgMenuOpen);
 
 	// Update _last_frame_duration and _last_present_time
 	const auto current_time = std::chrono::high_resolution_clock::now();

--- a/dllmain/LAApatch.cpp
+++ b/dllmain/LAApatch.cpp
@@ -1,16 +1,10 @@
 #include <iostream>
 #include "dllmain.h"
 #include "Patches.h"
-#include <d3d9.h>
 #include <shellapi.h>
 #include "Settings.h"
-#include "imgui\imgui.h"
-#include "imgui\imgui_impl_win32.h"
-#include "imgui\imgui_impl_dx9.h"
 
-LAApatch laa;
-
-bool LAApatch::GameIsLargeAddressAware()
+bool GameIsLargeAddressAware()
 {
 	static PBYTE module_base = reinterpret_cast<PBYTE>(GetModuleHandle(nullptr));
 
@@ -34,151 +28,106 @@ uint32_t calc_checksum(uint32_t checksum, void* data, int length) {
 	return checksum + (checksum >> 16);
 }
 
-LAADialogState LAA_State = LAADialogState::NotShowing;
-int LAA_ErrorNum = 0;
-void LAApatch::LAARender()
+void LAACheck()
 {
-	ImGuiIO& io = ImGui::GetIO();
+	static bool LAAChecked = false;
+	if (LAAChecked)
+		return; // user was prompted/EXE checked already, exit out
+
+	LAAChecked = true; // prevent us from checking more than once
 
 	if (GameIsLargeAddressAware())
+		return; // Game is already 4GB/LAA patched, exit out
+
+	spd::log()->info("Non-LAA executable detected!");
+
+	if (MessageBoxA(NULL,
+		"Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory.\n\nDo you want re4_tweaks to patch the game EXE for you?",
+		"4GB / Large Address Aware patch missing!",
+		MB_YESNO | MB_ICONEXCLAMATION) == IDYES)
 	{
-		// Exit out in case we needlessly ended up here somehow
-		LAA_State = LAADialogState::NotShowing;
-		return;
-	}
+		char module_path_array[4096];
+		GetModuleFileNameA(GetModuleHandle(nullptr), module_path_array, 4096);
 
-	if (LAA_State == LAADialogState::Showing)
-	{
-		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowSizeConstraints(ImVec2(400, 175), ImVec2(400, 175));
-		ImGui::Begin("4GB / Large Address Aware patch missing!");
-		ImGui::TextWrapped("Your game executable is missing the 4GB/LAA patch, this will likely cause issues with mods that require increased memory.\n\nDo you want re4_tweaks to patch the game EXE for you? (requires relaunch!)");
+		std::string module_path = module_path_array;
+		std::string module_path_new = module_path + ".new";
+		std::string module_path_bak = module_path + ".bak";
 
-		ImGui::Spacing();
-		ImGui::SetCursorPos(ImVec2(ImGui::GetWindowWidth() - 225, ImGui::GetWindowHeight() - 45));
+		if (GetFileAttributesA(module_path_new.c_str()) != 0xFFFFFFFF)
+			DeleteFileA(module_path_new.c_str());
 
-		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.51f, 0.00f, 0.14f, 1.00f));
+		if (GetFileAttributesA(module_path_bak.c_str()) != 0xFFFFFFFF)
+			DeleteFileA(module_path_bak.c_str());
 
-		if (ImGui::Button("Yes", ImVec2(104, 35)))
+		BOOL result_CopyFileA = CopyFileA(module_path.c_str(), module_path_new.c_str(), false);
+
+		FILE* file;
+		int LAA_ErrorNum = fopen_s(&file, module_path_new.c_str(), "rb+");
+		if (LAA_ErrorNum == 0)
 		{
-			char module_path_array[4096];
-			GetModuleFileNameA(GetModuleHandle(nullptr), module_path_array, 4096);
+			fseek(file, 0, SEEK_END);
+			std::vector<uint8_t> exe_data(ftell(file));
+			fseek(file, 0, SEEK_SET);
 
-			std::string module_path = module_path_array;
-			std::string module_path_new = module_path + ".new";
-			std::string module_path_bak = module_path + ".bak";
-
-			if (GetFileAttributesA(module_path_new.c_str()) != 0xFFFFFFFF)
-				DeleteFileA(module_path_new.c_str());
-
-			if (GetFileAttributesA(module_path_bak.c_str()) != 0xFFFFFFFF)
-				DeleteFileA(module_path_bak.c_str());
-
-			BOOL result_CopyFileA = CopyFileA(module_path.c_str(), module_path_new.c_str(), false);
-
-			FILE* file;
-			LAA_ErrorNum = fopen_s(&file, module_path_new.c_str(), "rb+");
-			if (LAA_ErrorNum == 0)
+			if (fread(exe_data.data(), 1, exe_data.size(), file) != exe_data.size())
 			{
-				fseek(file, 0, SEEK_END);
-				std::vector<uint8_t> exe_data(ftell(file));
-				fseek(file, 0, SEEK_SET);
+				fclose(file);
+				LAA_ErrorNum = 1;
+			}
+			else
+			{
+				PIMAGE_DOS_HEADER dos_header = reinterpret_cast<PIMAGE_DOS_HEADER>(exe_data.data());
+				PIMAGE_NT_HEADERS nt_headers = reinterpret_cast<PIMAGE_NT_HEADERS>(exe_data.data() + dos_header->e_lfanew);
 
-				if (fread(exe_data.data(), 1, exe_data.size(), file) != exe_data.size())
+				// Set LAA flag in PE headers
+				nt_headers->FileHeader.Characteristics |= IMAGE_FILE_LARGE_ADDRESS_AWARE;
+
+				// Fix up PE checksum
+				uint32_t header_size = (uintptr_t)nt_headers - (uintptr_t)exe_data.data() +
+					((uintptr_t)&nt_headers->OptionalHeader.CheckSum - (uintptr_t)nt_headers);
+
+				// Skip over CheckSum field
+				uint32_t remain_size = (exe_data.size() - header_size - 4) / sizeof(uint16_t);
+				void* remain = &nt_headers->OptionalHeader.Subsystem;
+
+				uint32_t header_checksum = calc_checksum(0, exe_data.data(), header_size / sizeof(uint16_t));
+				uint32_t file_checksum = calc_checksum(header_checksum, remain, remain_size);
+				if (exe_data.size() & 1)
+					file_checksum += *((char*)exe_data.data() + exe_data.size() - 1);
+
+				nt_headers->OptionalHeader.CheckSum = file_checksum + exe_data.size();
+
+				fseek(file, dos_header->e_lfanew, SEEK_SET);
+				auto wrote = fwrite(nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
+				fclose(file);
+
+				if (wrote != 1)
 				{
-					fclose(file);
-					LAA_ErrorNum = 1;
+					LAA_ErrorNum = 2;
 				}
 				else
 				{
-					PIMAGE_DOS_HEADER dos_header = reinterpret_cast<PIMAGE_DOS_HEADER>(exe_data.data());
-					PIMAGE_NT_HEADERS nt_headers = reinterpret_cast<PIMAGE_NT_HEADERS>(exe_data.data() + dos_header->e_lfanew);
+					BOOL result_moveFile1 = MoveFileExA(module_path.c_str(), module_path_bak.c_str(), MOVEFILE_REPLACE_EXISTING);
+					BOOL result_moveFile2 = MoveFileA(module_path_new.c_str(), module_path.c_str());
+					if (!result_moveFile1)
+						LAA_ErrorNum = 3;
+					else if (!result_moveFile2)
+						LAA_ErrorNum = 4;
 
-					// Set LAA flag in PE headers
-					nt_headers->FileHeader.Characteristics |= IMAGE_FILE_LARGE_ADDRESS_AWARE;
-
-					// Fix up PE checksum - required for some locales to work properly?
-					uint32_t header_size = (uintptr_t)nt_headers - (uintptr_t)exe_data.data() +
-						((uintptr_t)&nt_headers->OptionalHeader.CheckSum - (uintptr_t)nt_headers);
-
-					// Skip over CheckSum field
-					uint32_t remain_size = (exe_data.size() - header_size - 4) / sizeof(uint16_t);
-					void* remain = &nt_headers->OptionalHeader.Subsystem;
-
-					uint32_t header_checksum = calc_checksum(0, exe_data.data(), header_size / sizeof(uint16_t));
-					uint32_t file_checksum = calc_checksum(header_checksum, remain, remain_size);
-					if (exe_data.size() & 1)
-						file_checksum += *((char*)exe_data.data() + exe_data.size() - 1);
-
-					nt_headers->OptionalHeader.CheckSum = file_checksum + exe_data.size();
-
-					fseek(file, dos_header->e_lfanew, SEEK_SET);
-					auto wrote = fwrite(nt_headers, sizeof(IMAGE_NT_HEADERS), 1, file);
-					fclose(file);
-
-					if (wrote != 1)
+					if (result_moveFile1 && !result_moveFile2)
 					{
-						LAA_ErrorNum = 2;
-					}
-					else
-					{
-						BOOL result_moveFile1 = MoveFileExA(module_path.c_str(), module_path_bak.c_str(), MOVEFILE_REPLACE_EXISTING);
-						BOOL result_moveFile2 = MoveFileA(module_path_new.c_str(), module_path.c_str());
-						if (!result_moveFile1)
-							LAA_ErrorNum = 3;
-						else if (!result_moveFile2)
-							LAA_ErrorNum = 4;
-
-						if (result_moveFile1 && !result_moveFile2)
-						{
-							// Users original EXE was moved, but we couldn't move replacement for it for some reason
-							// Try restoring the users original EXE so they aren't left with a broken install...
-							MoveFileA(module_path_bak.c_str(), module_path.c_str());
-						}
+						// Users original EXE was moved, but we couldn't move replacement for it for some reason
+						// Try restoring the users original EXE so they aren't left with a broken install...
+						MoveFileA(module_path_bak.c_str(), module_path.c_str());
 					}
 				}
 			}
-			LAA_State = LAADialogState::Finished;
 		}
 
-		ImGui::SameLine();
-
-		if (ImGui::Button("No", ImVec2(104, 35)))
-		{
-			LAA_State = LAADialogState::NotShowing;
-		}
-
-		ImGui::PopStyleColor();
-
-		ImGui::End();
-	}
-	else if (LAA_State == LAADialogState::Finished)
-	{
-		// Prompted the user & finished performing patches, report the results back to them
-		ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-		ImGui::SetNextWindowSize(ImVec2(400, 175), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowSizeConstraints(ImVec2(400, 175), ImVec2(400, 175));
 		if (LAA_ErrorNum == 0)
 		{
-			ImGui::Begin("Game 4GB patched successfully!");
-			ImGui::TextWrapped("re4_tweaks has successfully patched your game EXE (a backup has also been made)\n\nPress OK to relaunch the game for the patch to take effect!");
-		}
-		else
-		{
-			ImGui::Begin("Game 4GB patch failed...");
-			ImGui::TextWrapped("re4_tweaks failed to patch the game EXE (error %d)\n\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should help find it!", LAA_ErrorNum);
-		}
-
-		ImGui::Dummy(ImVec2(0.0f, 15.0f));
-
-		ImGui::SetCursorPosX(ImGui::GetWindowWidth() - 113);
-
-		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.51f, 0.00f, 0.14f, 1.00f));
-
-		if (ImGui::Button("OK", ImVec2(104, 35)))
-		{
-			LAA_State = LAADialogState::NotShowing;
+			MessageBoxA(NULL, "re4_tweaks has successfully patched your game EXE (a backup has also been made)\n\nPress OK to relaunch the game for the patch to take effect!", 
+				"Game 4GB patched successfully!", 0);
 
 			// Relaunch the game
 			std::string bio4path = rootPath + "bio4.exe";
@@ -188,9 +137,11 @@ void LAApatch::LAARender()
 				return;
 			}
 		}
-
-		ImGui::PopStyleColor();
-
-		ImGui::End();
+		else
+		{
+			char errText[256];
+			sprintf_s(errText, "re4_tweaks failed to patch the game EXE (error %d)\n\nYou can manually patch it yourself by using the \"NTCore 4GB Patch\" tool - an internet search should help find it!", LAA_ErrorNum);
+			MessageBoxA(NULL, errText, "Game 4GB patch failed...", MB_ICONEXCLAMATION);
+		}
 	}
 }

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -473,13 +473,6 @@ bool cPlayer__keyReload_hook()
 
 void Init_Misc()
 {
-	// Check if the exe is LAA
-	if (!laa.GameIsLargeAddressAware())
-	{
-		spd::log()->info("Non-LAA executable detected!");
-		laa.LAA_State = LAADialogState::Showing; // Show LAA patch prompt
-	}
-
 	// Hook cPlayer::keyReload to allow reloading without aiming
 	{
 		auto pattern = hook::pattern("E8 ? ? ? ? 84 C0 74 3A 8B 86 ? ? ? ? 39 58 ? 74 ? 8B 40");

--- a/dllmain/Patches.h
+++ b/dllmain/Patches.h
@@ -87,22 +87,8 @@ struct ConsoleOutput
 extern ConsoleOutput con;
 extern bool bConsoleOpen;
 
-// LAApatch
-enum class LAADialogState
-{
-	NotShowing,
-	Showing,
-	Finished // show dialog telling user that LAA patch is complete, etc
-};
-
-struct LAApatch
-{
-	void LAARender();
-	bool GameIsLargeAddressAware();
-	LAADialogState LAA_State;
-};
-
-extern LAApatch laa;
+// LAApatch.cpp
+void LAACheck();
 
 // Controller tweaks
 extern int* g_XInputDeadzone_LS;

--- a/dllmain/WndProcHook.cpp
+++ b/dllmain/WndProcHook.cpp
@@ -172,6 +172,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CreateWindowExA hook to get the hWindow and set up the WndProc hook
 HWND __stdcall CreateWindowExA_Hook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
+	// Perform LAA check/prompt before game window has a chance to be created
+	LAACheck();
+
 	int windowX = pConfig->iWindowPositionX < 0 ? CW_USEDEFAULT : pConfig->iWindowPositionX;
 	int windowY = pConfig->iWindowPositionY < 0 ? CW_USEDEFAULT : pConfig->iWindowPositionY;
 


### PR DESCRIPTION
Changed it to use standard `MessageBox` before game window is shown or any textures are loaded.

Had to move the actual call to our LAA check stuff to our `CreateWindow` hook instead, tried handling it inside `DllMain` but that just made `ShellExecute` hang instead of relaunching, AFAIK that's something to do with [loader lock issues](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices)...

Seems to patch/relaunch it fine this way though, also tested with EXE renamed after launching to make sure error msg func still works, all seems OK.

Since the game window doesn't even have a chance to show before this I removed part of the text about needing to relaunch the game, could maybe even remove the messagebox after the patch has finished and just go straight to relaunching, idk though, maybe it's better to let people know that our patching worked :p

(really we could probably remove all the messageboxes and just do it pretty much in the background, and only prompt user if patching failed... not really sure about trying to edit game files without letting users know about it first though, guess it's probably best to give some kind of prompt)

E: force push just touched up one of the comments, and re-added the "Non-LAA executable detected!" log.