### PR TITLE
EnableModExpansion: allows overriding scale/speed inside ESL entries

### DIFF
--- a/dllmain/AspectRatioTweaks.cpp
+++ b/dllmain/AspectRatioTweaks.cpp
@@ -119,7 +119,11 @@ void Init_AspectRatioTweaks()
 		void operator()(injector::reg_pack& regs)
 		{
 			// Code we replaced
-			__asm {fstp dword ptr[eax + 0x10C]}
+			uint32_t orig_eax = regs.eax;
+			__asm {
+				mov eax, [orig_eax]
+				fstp dword ptr[eax + 0x10C]
+			}
 
 			float* fCurHudPosX = (float*)(regs.eax - 0x1DCC);
 

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -116,6 +116,17 @@ uint8_t* GameSavePtr()
 	return *g_GameSave_BufPtr;
 }
 
+bool IsGanado(int id) // same as games IsGanado func
+{
+	if (id == 0x4B || id == 0x4E)
+		return 0;
+	if ((unsigned int)(id - 0x40) <= 0xF)
+		return 1;
+	if (id < 0x10)
+		return 0;
+	return id <= 0x20;
+}
+
 // Original game funcs
 bool(__cdecl* game_KeyOnCheck_0)(KEY_BTN a1);
 void(__cdecl* game_C_MTXOrtho)(Mtx44 mtx, float PosY, float NegY, float NegX, float PosX, float Near, float Far);

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -816,11 +816,31 @@ static_assert(sizeof(cEm) == 0x408, "sizeof(cEm)");
 struct ETS_DATA
 {
 	uint16_t EtcModelId_0;
-	uint16_t EtcModelNo_2;
-	Vec scale_4;
+
+	// normally uint16_t, but game only allows values 0x40 and below
+	// we patch game to read it as byte, which gives us a free byte to use as flag :)
+	union
+	{
+		uint16_t EtcModelNo_2; // vanilla
+		struct
+		{
+			uint8_t expansion_EtcModelNo_2;
+			uint8_t expansion_Flag_3;
+		};
+	};
+	union
+	{
+		Vec scale_4; // vanilla
+		struct
+		{
+			SVEC expansion_PercentScaleModel_4;
+			SVEC expansion_PercentScaleCollision_A;
+		};
+	};
 	Vec rotation_10;
 	Vec position_1C;
 };
+static_assert(sizeof(ETS_DATA) == 0x28, "sizeof(ETS_DATA)");
 
 std::string GameVersion();
 bool GameVersionIsDebug();

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -813,6 +813,15 @@ public:
 };
 static_assert(sizeof(cEm) == 0x408, "sizeof(cEm)");
 
+struct ETS_DATA
+{
+	uint16_t EtcModelId_0;
+	uint16_t EtcModelNo_2;
+	Vec scale_4;
+	Vec rotation_10;
+	Vec position_1C;
+};
+
 std::string GameVersion();
 bool GameVersionIsDebug();
 InputDevices LastUsedDevice();

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -189,25 +189,31 @@ enum EM_BE_FLAG : uint8_t
   EM_BE_FLAG_DIE = 0x80,
 };
 
+struct SVEC
+{
+	int16_t x;
+	int16_t y;
+	int16_t z;
+};
+
 struct EM_LIST
 {
-  EM_BE_FLAG be_flag_0;
-  char id_1;
-  char type_2;
-  char set_3;
-  uint32_t em_flag_4;
-  int16_t hp_8;
-  uint8_t gapA;
-  char charaId_B;
-  int16_t posX_C;
-  int16_t posY_E;
-  int16_t posZ_10;
-  int16_t rotX_12;
-  int16_t rotY_14;
-  int16_t rotZ_16;
-  int16_t roomId_18;
-  int16_t guardRadius_1A;
-  uint8_t gap1C[4];
+	EM_BE_FLAG be_flag_0;
+	char id_1;
+	char type_2;
+	char set_3;
+	uint32_t flag_4;
+	int16_t hp_8;
+	uint8_t emset_no_A;
+	char Character_B;
+	SVEC s_pos_C;
+	SVEC s_ang_12;
+	uint16_t room_18;
+	int16_t Guard_r_1A;
+
+	// extended params added by re4_tweaks, normally field is Dummy / unused
+	uint16_t percentageMotionSpeed_1C;
+	uint16_t percentageScale_1E;
 };
 static_assert(sizeof(EM_LIST) == 0x20, "sizeof(EM_LIST)"); // TODO: find if this size is correct
 
@@ -556,6 +562,257 @@ struct DatTbl
 };
 static_assert(sizeof(DatTbl) == 8, "sizeof(DatTbl)");
 
+class cUnit
+{
+public:
+	uint32_t be_flag_4;
+	cUnit* pNext_8;
+
+	virtual ~cUnit() = 0;
+	virtual void beginEvent(uint32_t) = 0;
+	virtual void endEvent(uint32_t) = 0;
+};
+
+class cCoord : public cUnit
+{
+public:
+	Mtx mat_C;
+	Mtx l_mat_3C;
+	cCoord* pParent_6C;
+	Vec world_70;
+	Vec world_old_7C;
+	Vec world_old2_88;
+	Vec pos_94;
+	Vec ang_A0;
+	Vec scale_AC;
+	Vec r_scale_B8;
+
+	virtual void matUpdate() = 0;
+};
+
+class cLightInfo
+{
+public:
+	Mtx* imat_0;
+	DWORD cLightInfo_field_4;
+	DWORD cLightInfo_field_8;
+	DWORD cLightInfo_field_C;
+	Vec position_10;
+	Vec rotation_1C;
+	Vec scale_28;
+	int32_t cLightInfo_field_34;
+	int32_t cLightInfo_field_38;
+	int32_t cLightInfo_field_3C;
+	int32_t cLightInfo_field_40;
+	int32_t cLightInfo_field_44;
+	int32_t cLightInfo_field_48;
+	int32_t cLightInfo_field_4C;
+	uint8_t EnableMask_50;
+	uint8_t Flag_51;
+	int8_t PartsNo_52;
+	uint8_t dummy03_53;
+	uint32_t SelectMask_54;
+	Vec Offset_58;
+	Vec Size_64;
+	float Radius_70;
+};
+
+class cModel;
+
+class cAtariInfo
+{
+public:
+	Vec m_offset_0;
+	float m_radius_C;
+	float m_radius2_10;
+	float m_height_14;
+	int16_t m_parts_no_18;
+	uint16_t m_flag_1A;
+	float m_radius_n_1C;
+	float m_radius2_n_20;
+	uint16_t m_hokan_24;
+	uint16_t m_stat_26;
+	cModel* m_pMod_28;
+	float m_radius3_2C;
+	Vec m_Pos_30;
+	Vec m_oldPos_3C;
+	cAtariInfo* m_pList_48;
+};
+
+class cModelState
+{
+public:
+	uint32_t m_Flag_0;
+	uint32_t m_LightFlag_4;
+	uint32_t m_LightNo_8;
+	float m_LightPow_C;
+};
+
+class cModel : public cCoord
+{
+public:
+	Mtx mtx_C4;
+	class cParts* childParts_F4;
+	uint32_t guid_F8;
+	uint8_t r_no_0_FC;
+	uint8_t r_no_1_FD;
+	uint8_t r_no_2_FE;
+	uint8_t r_no_3_FF;
+	uint8_t id_100;
+	uint8_t type_101;
+	uint8_t nParts_102;
+	uint8_t alpha_omit_103;
+	Vec speed_104;
+	Vec pos_old_110;
+	Vec Wall_norm_11C;
+	Vec* pFloor_norm_128;
+	uint8_t z_mode_12C;
+	uint8_t TevScaleGroup_12D;
+	uint8_t kindid_12E;
+	uint8_t ot_type_12F;
+	cModel* pChildShadowModel_130;
+	uint8_t Shd_color_134;
+	uint8_t CullMode_135;
+	uint8_t Shader_type_136;
+	uint8_t Refract_pow_137;
+	uint8_t Refract_ratio_138;
+	uint8_t AddAmb_r_139;
+	uint8_t AddAmb_g_13A;
+	uint8_t AddAmb_b_13B;
+	uint32_t Fix_parts_13C;
+	Vec Fix_pos_140;
+	uint8_t invisible_trg_14C;
+	uint8_t invisible_old_14D;
+	uint8_t invisible_mode_14E;
+	uint8_t invisible_busy_14F;
+	int32_t invisible_timer_150;
+	float invisible_factor_154;
+	float invisible_factor2_158;
+	class cModelInfo* pModelInfo_15C;
+	class cModelInfo* pShadowModelInfo_160;
+	cLightInfo LightInfo_164;
+	MOTION_INFO Motion_1D8;
+	MOTION_INFO* pMotionB_2A8;
+	int16_t* pXFlip_2AC;
+	uint32_t* pDblJnt_2B0;
+	cAtariInfo atari_2B4;
+	Vec* inscreen_pos_300;
+	uint32_t pPath_304;
+	struct FOOTSHADOW_TBL* pFsdTbl_308;
+	cModelState State_30C;
+	int32_t field_31C;
+	uint8_t field_320;
+	uint8_t field_321;
+	uint8_t field_322;
+	uint8_t field_323;
+
+	virtual void move() = 0;
+	virtual void setNoSuspend(uint32_t) = 0;
+};
+static_assert(sizeof(cModel) == 0x324, "sizeof(cModel)");
+
+struct YARARE_INFO
+{
+	Vec offset_0;
+	Vec cross_C;
+	float radius_18;
+	float height_1C;
+	float extent_20;
+	uint16_t flag_24;
+	int16_t parts_no_26;
+	float len_28;
+	float c_dis_2C;
+	YARARE_INFO* nextInfo_30;
+};
+
+class cDmgInfo
+{
+public:
+	// old version of cDmgInfo only had a single float member
+	// unsure if this float is actually m_Dist or not, it might be m_Timer, since a lot of timer related stuff got changed to float during 60FPS change
+	float m_Dist_mb_0;
+	uint8_t m_Flag_4;
+	uint8_t m_Timer_mb_5;
+	uint8_t m_Wep_6;
+	uint8_t m_Padding03_7;
+	Vec m_PosFrom_8;
+	float m_Dist_mb_14;
+	YARARE_INFO* m_pDamageYarare_18;
+};
+
+class cEm : public cModel
+{
+public:
+	enum class Routine0 : uint8_t
+	{
+		// r0 values that are used by pretty much all cEms
+		// (other r* values are usually defined per-cEm though)
+		Init,
+		Move,
+		Damage,
+		Die
+	};
+
+	int16_t hp_324;
+	int16_t hp_max_326;
+	cDmgInfo m_DmgInfo_328;
+	YARARE_INFO yarare_344;
+	float l_pl_378;
+	float l_sub_37C;
+	void* pFile_380;
+	void* pFile2_384;
+	Vec target_offset0_388;
+	char target_parts0_394;
+	uint8_t set_395;
+	uint8_t emunk_396[2];
+	int(__cdecl* sce_func_398)(cEm*);
+	uint8_t emunk_39C[4];
+	uint8_t emListIndex_3A0;
+	uint8_t emunk_field_3A1;
+	uint8_t emunk_3A2[2];
+	Vec motionMove2Vec_3A4;
+	Vec Catch_at_adj_3B0;
+	float Catch_dir_3BC;
+	cEm* pEmCatch_3C0;
+	uint8_t RckStat_3C4;
+	int8_t RckMy_3C5;
+	int8_t RckTo_3C6;
+	int8_t RckNear_3C7;
+	int8_t RckRno_3C8;
+	int8_t RckPad0_3C9;
+	uint8_t emunk_3CA[2];
+	uint32_t m_StatusFlag_3CC;
+	uint32_t flag_3D0;
+	float Guard_r_3D4;
+	uint8_t characterNum_3D8;
+	uint8_t Item_eff_3D9;
+	uint8_t emunk_3DA[4];
+	uint16_t Item_id_3DE;
+	uint16_t Item_num_3E0;
+	uint16_t Item_flg_3E2;
+	uint16_t Auto_item_flg_3E4;
+	uint8_t emunk_3E6[2];
+	uint32_t flags_3E8;
+	Vec emunk_field_3EC;
+	Vec target_offset1_3F8;
+	int32_t target_parts1_404;
+
+	virtual void setItem(int16_t a2, int16_t a3, int16_t a4, int16_t a5, int8_t a6) = 0;
+	virtual void setNoItem() = 0;
+	virtual bool checkThrow() = 0;
+
+	inline bool IsValid()
+	{
+		return (be_flag_4 & 0x601) != 0;
+	}
+
+	inline bool IsSpawnedByESL()
+	{
+		return IsValid() && emListIndex_3A0 != 255;
+	}
+};
+static_assert(sizeof(cEm) == 0x408, "sizeof(cEm)");
+
 std::string GameVersion();
 bool GameVersionIsDebug();
 InputDevices LastUsedDevice();
@@ -572,6 +829,7 @@ SYSTEM_SAVE* SystemSavePtr();
 cPlayer* PlayerPtr();
 cPlayer* AshleyPtr();
 uint8_t* GameSavePtr();
+bool IsGanado(int id);
 
 // Length seems to always be 0xFFAA0 across all builds
 #define GAMESAVE_LENGTH 0xFFAA0

--- a/dllmain/ModExpansion.cpp
+++ b/dllmain/ModExpansion.cpp
@@ -92,7 +92,47 @@ BOOL __fastcall cEtcTbl__RegistData_Hook(void* thisptr, void* unused, ETS_DATA* 
 	// (why doesn't game do this already? ETS data already has a field specifically for scale...)
 	if (ret && pPtr)
 	{
-		pPtr->scale_AC = pEts->scale_4;
+		Vec scale_model = pEts->scale_4;
+		Vec scale_collision = scale_model;
+
+		// Check if "short mode" flag is set
+		// If it is, the 12 bytes for scale are treated as two 6-byte "short vectors"
+		// First vector controls the scale of model, second one controls collision scale
+		// Both "short vector" values are treated as percentages, eg. setting to 200 will scale by 2x
+		// If the flag isn't set then both model & collision are scaled by the normal 12-byte scale vector
+		if (pEts->expansion_Flag_3 == 0xF0)
+		{
+			scale_model.x = float(double(pEts->expansion_PercentScaleModel_4.x) / 100.0f);
+			scale_model.y = float(double(pEts->expansion_PercentScaleModel_4.y) / 100.0f);
+			scale_model.z = float(double(pEts->expansion_PercentScaleModel_4.z) / 100.0f);
+			scale_collision.x = float(double(pEts->expansion_PercentScaleCollision_A.x) / 100.0f);
+			scale_collision.y = float(double(pEts->expansion_PercentScaleCollision_A.y) / 100.0f);
+			scale_collision.z = float(double(pEts->expansion_PercentScaleCollision_A.z) / 100.0f);
+
+			// Remove flag in case game reads EtcModelId somewhere else...
+			pEts->expansion_Flag_3 = 0;
+		}
+
+		pPtr->scale_AC = scale_model;
+
+		pPtr->atari_2B4.m_height_14 *= scale_collision.z;
+
+		// Update "rs" values - radius [for] square?
+		pPtr->atari_2B4.m_radius_C *= scale_collision.x;
+		pPtr->atari_2B4.m_radius_n_1C *= scale_collision.x;
+
+		// Update "ro" values
+		pPtr->atari_2B4.m_radius2_10 *= scale_collision.x;
+		pPtr->atari_2B4.m_radius2_n_20 *= scale_collision.x;
+
+		// Update "ra" values
+		pPtr->atari_2B4.m_radius3_2C *= scale_collision.x;
+
+		// Some models collision seems to use an offset for some reason
+		// Multiplying against our scale mostly seems to fix it though
+		pPtr->atari_2B4.m_offset_0.x *= scale_collision.x;
+		pPtr->atari_2B4.m_offset_0.y *= scale_collision.y;
+		pPtr->atari_2B4.m_offset_0.z *= scale_collision.z;
 	}
 	return ret;
 }
@@ -120,4 +160,10 @@ void Init_ModExpansion()
 	auto cEtcTbl__RegistData_thunk = (uint8_t*)injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0xF)).as_int();
 	ReadCall(cEtcTbl__RegistData_thunk, cEtcTbl__RegistData);
 	InjectHook(cEtcTbl__RegistData_thunk, cEtcTbl__RegistData_Hook, PATCH_JUMP);
+
+	// Patch ETS-loading func to read EtcModelNo_2 as byte
+	// which gives us a spare byte to use as a flag to change how scale values are read
+	// (game only allows EtcModelNo_2 values 0x40 and below anyway, so the byte was pretty much wasted...)
+	pattern = hook::pattern("51 0F B7 46 02");
+	Patch(pattern.count(1).get(0).get<uint8_t>(2), uint8_t(0xB6)); // change "movzx eax, word ptr" -> movzx eax, byte ptr"
 }

--- a/dllmain/ModExpansion.cpp
+++ b/dllmain/ModExpansion.cpp
@@ -1,0 +1,102 @@
+#include <iostream>
+#include "dllmain.h"
+#include "Patches.h"
+#include "Game.h"
+#include "Settings.h"
+
+void SetEmListParamExtensions(cEm* em, EM_LIST* emData)
+{
+	// Game sometimes uses hardcoded stack-based EM_LIST to spawn certain enemies
+	// In those cases, 0xA & 0x1C usually are left untouched, resulting in random stack data being used
+	// To protect against that, we'll only allow param extensions from emData that came from pG->emList_5410
+	GLOBALS* pG = GlobalPtr();
+	if (emData < pG->emList_5410 || emData >= &pG->emList_5410[256])
+		return;
+
+	// check emset_no_A field to see if custom speed/scale params have been set
+	// emset_no_A seems to mostly be unused, but the field is defined in the struct, so maybe something has it set
+	// hopefully nothing has all upper bits set though
+	if ((emData->emset_no_A & 0xF0) != 0xF0)
+		return;
+
+	emData->emset_no_A &= ~0xF0; // unset upper bits that we checked
+
+	if (!emData->percentageMotionSpeed_1C && !emData->percentageScale_1E)
+		return;
+
+	// let it run the cEm's EmXX_R0_init function before we apply changes
+	// (since that has a good chance of overwriting scale value)
+	if (em->r_no_0_FC == uint8_t(cEm::Routine0::Init))
+		em->move();
+
+	if (emData->percentageMotionSpeed_1C)
+		em->Motion_1D8.speed_C0 = float(double(emData->percentageMotionSpeed_1C) / 100.0f);
+
+	if (emData->percentageScale_1E)
+	{
+		auto scalePercent = float(double(emData->percentageScale_1E) / 100.0f);
+		em->scale_AC.x *= scalePercent;
+		em->scale_AC.y *= scalePercent;
+		em->scale_AC.z *= scalePercent;
+
+		if (IsGanado(em->id_100))
+		{
+			// cEm10 holds a seperate scale value that it seems to grow/shrink the actual scale towards each frame
+			// make sure we update that as well
+			Vec* scale_bk_498 = (Vec*)((uint8_t*)em + 0x498);
+			*scale_bk_498 = em->scale_AC;
+		}
+	}
+}
+
+cEm* (__cdecl* EmSetEvent)(EM_LIST* emData);
+cEm* __cdecl EmSetEvent_Hook(EM_LIST* emData)
+{
+	cEm* result = EmSetEvent(emData);
+	// TODO: check if result == errEm
+
+	SetEmListParamExtensions(result, emData);
+	return result;
+}
+
+cEm* (__cdecl* EmSetFromList2)(unsigned int em_list_no, int a2);
+cEm* __cdecl EmSetFromList2_Hook(unsigned int em_list_no, int a2)
+{
+	cEm* result = EmSetFromList2(em_list_no, a2);
+	SetEmListParamExtensions(result, &GlobalPtr()->emList_5410[em_list_no]);
+
+	return result;
+}
+
+void __fastcall EmSetFromList_Hook(cEm* em, uint32_t unused)
+{
+	SetEmListParamExtensions(em, &GlobalPtr()->emList_5410[em->emListIndex_3A0]);
+	em->move(); // code we patched to jump here
+}
+
+void __declspec(naked) EmSetFromList_Hook_Trampoline()
+{
+	__asm
+	{
+		mov ecx, eax
+		jmp EmSetFromList_Hook
+	}
+}
+
+void Init_ModExpansion()
+{
+	// Hook ESL-loading functions so we can add extended scale/speed parameters
+	auto pattern = hook::pattern("52 66 89 45 E4 66 89 4D F6 E8");
+	auto EmSetEvent_thunk = (uint8_t*)injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(9)).as_int();
+	ReadCall(EmSetEvent_thunk, EmSetEvent);
+	InjectHook(EmSetEvent_thunk, EmSetEvent_Hook, PATCH_JUMP);
+
+	pattern = hook::pattern("6A 01 6A 32 E8 ? ? ? ? 83 C4 20");
+	auto EmSetFromList2_thunk = (uint8_t*)injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(4)).as_int();
+	ReadCall(EmSetFromList2_thunk, EmSetFromList2);
+	InjectHook(EmSetFromList2_thunk, EmSetFromList2_Hook, PATCH_JUMP);
+
+	pattern = hook::pattern("D9 98 7C 03 00 00 8B 42 10");
+	auto EmSetFromList_mov = pattern.count(1).get(0).get<uint8_t>(6);
+	InjectHook(EmSetFromList_mov, EmSetFromList_Hook_Trampoline, PATCH_CALL);
+}

--- a/dllmain/Patches.h
+++ b/dllmain/Patches.h
@@ -23,6 +23,7 @@ void Init_KeyboardMouseTweaks();
 void Init_MouseTurning();
 void Init_MathReimpl();
 void Init_Misc();
+void Init_ModExpansion();
 void Init_QTEfixes();
 void Init_sofdec();
 void Init_ToolMenu();

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -272,6 +272,7 @@ void Config::ReadSettings(std::string_view ini_path)
 	pConfig->bAutomaticMashingQTE = iniReader.ReadBoolean("MISC", "AutomaticMashingQTE", pConfig->bAutomaticMashingQTE);
 	pConfig->bSkipIntroLogos = iniReader.ReadBoolean("MISC", "SkipIntroLogos", pConfig->bSkipIntroLogos);
 	pConfig->bEnableDebugMenu = iniReader.ReadBoolean("MISC", "EnableDebugMenu", pConfig->bEnableDebugMenu);
+	pConfig->bEnableModExpansion = iniReader.ReadBoolean("MISC", "EnableModExpansion", pConfig->bEnableModExpansion);
 
 	// MEMORY
 	pConfig->bAllowHighResolutionSFD = iniReader.ReadBoolean("MEMORY", "AllowHighResolutionSFD", pConfig->bAllowHighResolutionSFD);
@@ -453,6 +454,7 @@ DWORD WINAPI WriteSettingsThread(LPVOID lpParameter)
 	iniReader.WriteBoolean("MISC", "AutomaticMashingQTE", pConfig->bAutomaticMashingQTE);
 	iniReader.WriteBoolean("MISC", "SkipIntroLogos", pConfig->bSkipIntroLogos);
 	iniReader.WriteBoolean("MISC", "EnableDebugMenu", pConfig->bEnableDebugMenu);
+	iniReader.WriteBoolean("MISC", "EnableModExpansion", pConfig->bEnableModExpansion);
 
 	// MEMORY
 	iniReader.WriteBoolean("MEMORY", "AllowHighResolutionSFD", pConfig->bAllowHighResolutionSFD);
@@ -590,6 +592,7 @@ void Config::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "AutomaticMashingQTE", pConfig->bAutomaticMashingQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "SkipIntroLogos", pConfig->bSkipIntroLogos ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableDebugMenu", pConfig->bEnableDebugMenu ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "EnableModExpansion", pConfig->bEnableModExpansion ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 
 	// MEMORY

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -95,6 +95,7 @@ public:
 	bool bAutomaticMashingQTE = false;
 	bool bSkipIntroLogos = false;
 	bool bEnableDebugMenu = false;
+	bool bEnableModExpansion = false;
 
 	// MEMORY
 	bool bAllowHighResolutionSFD = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1313,6 +1313,23 @@ void cfgMenuRender()
 						ImGui::TextWrapped("(may have a rare chance to cause a heap corruption crash when loading a save, but if the game loads fine then there shouldn't be any chance of crashing)");
 					}
 
+					// EnableModExpansion
+					{
+						ImGui_ColumnSwitch();
+
+						if (ImGui::Checkbox("EnableModExpansion", &pConfig->bEnableModExpansion))
+						{
+							pConfig->HasUnsavedChanges = true;
+							NeedsToRestart = true;
+						}
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10));
+						ImGui::TextWrapped("Enables patches/hooks for expanded modding capabilities, such as allowing enemy speed & scale to be defined when spawning.");
+						ImGui::TextWrapped("Only needed when using mods that specifically require it, otherwise should be left disabled.");
+					}
+
 					ImGui_ColumnFinish();
 					ImGui::EndTable();
 				}

--- a/dllmain/dllmain.cpp
+++ b/dllmain/dllmain.cpp
@@ -82,6 +82,9 @@ void Init_Main()
 
 	Init_Misc();
 
+	if (pConfig->bEnableModExpansion)
+		Init_ModExpansion();
+
 	Init_MathReimpl();
 
 	// Apply changes needed by the HD Project

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -141,6 +141,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     <ClCompile Include="KeyboardMouseTweaks.cpp" />
     <ClCompile Include="LAApatch.cpp" />
     <ClCompile Include="Misc.cpp" />
+    <ClCompile Include="ModExpansion.cpp" />
     <ClCompile Include="MouseTurning.cpp" />
     <ClCompile Include="QTEFixes.cpp" />
     <ClCompile Include="MathReimpl.cpp" />

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClCompile Include="HDProject.cpp">
       <Filter>dllmain</Filter>
     </ClCompile>
+    <ClCompile Include="ModExpansion.cpp">
+      <Filter>dllmain</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\external\inireader\ini_parser.hpp">

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -246,6 +246,11 @@ SkipIntroLogos = false
 ; (may have a rare chance to cause a heap corruption crash when loading a save, but if the game loads fine then there shouldn't be any chance of crashing)
 EnableDebugMenu = false
 
+; Enables patches/hooks for expanded modding capabilities, such as allowing enemy speed & scale to be defined when spawning.
+; Only needed when using mods that specifically require it, otherwise should be left disabled.
+; (modders that require this to be enabled can force it by including a override INI with their mod, see "dist/Bin32/re4_tweaks/setting_overrides/overrides_info.txt" file)
+EnableModExpansion = false
+
 [MEMORY]
 ; Allocate more memory for SFD movie files, and properly scale its resolution display above 512x336.
 ; Not tested beyond 1920x1080.

--- a/settings/settings_string.h
+++ b/settings/settings_string.h
@@ -248,7 +248,8 @@ EnableDebugMenu = false
 
 ; Enables patches/hooks for expanded modding capabilities, such as allowing enemy speed & scale to be defined when spawning.
 ; Only needed when using mods that specifically require it, otherwise should be left disabled.
-; (modders that require this to be enabled can force it by including a override INI with their mod, see "dist/Bin32/re4_tweaks/setting_overrides/overrides_info.txt" file)
+; (more info about what this adds can be found here: https://github.com/nipkownix/re4_tweaks/pull/305)
+; (modders that require this to be enabled can force it by including a override INI with their mod, see "re4_tweaks/setting_overrides/overrides_info.txt" file)
 EnableModExpansion = false
 
 [MEMORY]


### PR DESCRIPTION
Separated the ESL expansion stuff from #266, since I'm probably gonna redo that PR eventually, and I guess it's better to get this stuff in sooner than later.

This adds a `EnableModExpansion` setting which enables the hooks for allowing scale/speed to be set inside ESL, had to change how the flag for enabling speed/scale is set though, since it seems 0xA might actually be in use (I didn't see any code using it, but the field is defined)
Now instead of setting 0xA to 1, you'll need to set the first nibble of it to F instead.
eg. if 0xA was set to `03`, you'd set it to `F3`, or if 0xA is `00` just set it to `F0`.
With that set the last 4 bytes of the ESL entry will be treated as two uint16_t percentage values, first one as speed percent, second as scale percent.

Also added stuff to allow scaling in ETS as well, as requested at #303, more info in the comment below, seems to be working fine from what I've heard 😸 

Still need to fix the interaction issue mentioned below though... hopefully can figure something out for it soon.