### PR TITLE
A bug was occured in v1.0.6

### DIFF
--- a/dllmain/AspectRatioTweaks.cpp
+++ b/dllmain/AspectRatioTweaks.cpp
@@ -118,7 +118,7 @@ void Init_AspectRatioTweaks()
 	{
 		void operator()(injector::reg_pack& regs)
 		{
-			// Code we replaced
+			// Code we replaced eax=0xCCCCCCCC in v1.0.6
 			__asm {fstp dword ptr[eax + 0x10C]}
 
 			float* fCurHudPosX = (float*)(regs.eax - 0x1DCC);

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -374,10 +374,10 @@ struct __declspec(align(4)) GLOBALS
   uint16_t totalDead_8462;
   uint32_t chapterKill_8464;
   uint32_t totalKill_8468;
-  uint32_t chapterShot_846C;
-  uint32_t totalShot_8470;
-  uint32_t chapterHit_8474;
-  uint32_t totalHit_8478;
+  uint32_t chapterHit_846C;
+  uint32_t totalHit_8470;
+  uint32_t chapterShot_8474;
+  uint32_t totalShot_8478;
   uint8_t curMode_847C; // Dynamic max 6 in pro 
   uint8_t field_847D;
   uint8_t field_847E;


### PR DESCRIPTION
```cpp
        // The old edition has not this prob
	// Hook LifeMeter::roomInit so we can override the initial HUD pos
	pattern = hook::pattern("8B 48 ? 8B 51 ? 6A ? 6A ? 03 D1 68 ? ? ? ? 52 B9 ? ? ? ? E8 ? ? ? ? 6A");
	struct LMroomInit_Hook
	{
		void operator()(injector::reg_pack& regs)
		{
			regs.ecx = *(uint32_t*)(regs.eax + 0x48);
			regs.edx = *(uint32_t*)(regs.ecx + 0x7C);

			if ((pConfig->bSideAlignHUD && bIsUltrawide) || bIs16by10)
			{
				// I honestly don't understand this pointer and/or the data structure it points to
				float* fInitialHudPosX = (float*)(regs.ecx + regs.edx + 0x1C);

				float fHudPosOffset = 0.25f * (fGameWidth - (fDefaultEngineAspectRatio * fGameHeight));

				*fInitialHudPosX = fDefaultHudPosX + fHudPosOffset;

				#ifdef VERBOSE
				con.AddConcatLog("fInitialHudPosX: ", *fInitialHudPosX);
				#endif
			}
		}
	}; injector::MakeInline<LMroomInit_Hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));

```