### PR TITLE
ModExpansion: change flag offset 0xA to 0x0 - add 0x40 to set it

### DIFF
--- a/dllmain/ModExpansion.cpp
+++ b/dllmain/ModExpansion.cpp
@@ -13,13 +13,8 @@ void SetEmListParamExtensions(cEm* em, EM_LIST* emData)
 	if (emData < pG->Em_list_5410 || emData >= &pG->Em_list_5410[256])
 		return;
 
-	// check emset_no_A field to see if custom speed/scale params have been set
-	// emset_no_A seems to mostly be unused, but the field is defined in the struct, so maybe something has it set
-	// hopefully nothing has all upper bits set though
-	if ((emData->emset_no_A & 0xF0) != 0xF0)
+	if ((emData->be_flag_0 & EM_BE_FLAG_MODEXP_SPEEDSCALE) != EM_BE_FLAG_MODEXP_SPEEDSCALE)
 		return;
-
-	emData->emset_no_A &= ~0xF0; // unset upper bits that we checked
 
 	if (!emData->percentageMotionSpeed_1C && !emData->percentageScale_1E)
 		return;

--- a/dllmain/SDK/em_set.h
+++ b/dllmain/SDK/em_set.h
@@ -5,6 +5,18 @@ enum EM_BE_FLAG : uint8_t
 {
 	EM_BE_FLAG_ALIVE = 0x1,
 	EM_BE_FLAG_SET = 0x2,
+
+	// if one of these two are set, game seems to swap between them when loading
+	// maybe as some way of telling if it's loaded from a save or from a file?
+	// only starts doing it if one of them is set though...
+	EM_BE_FLAG_UNK4 = 0x4,
+	EM_BE_FLAG_UNK8 = 0x8,
+
+	// flags for ModExpansion.cpp SetEmListParamExtensions
+	EM_BE_FLAG_MODEXP_10 = 0x10, // available for use
+	EM_BE_FLAG_MODEXP_20 = 0x20, // available for use
+	EM_BE_FLAG_MODEXP_SPEEDSCALE = 0x40, // indicates speed/scale values should be set from inside ESL data
+
 	EM_BE_FLAG_DIE = 0x80,
 };
 


### PR DESCRIPTION
This changes the byte we use to indicate that speed/scale should be updated, normally it'd update 0xA, but that field was already defined for use by the game (haven't seen any code that uses it though...), and also seems some stack-allocated `EM_LIST` instances could have random data there too.;

Instead of using that, it looks like the be_flag field has 3 bits unused (0x10/0x20/0x40) that we can appropriate instead, none of the UHD ESL files make use of them at least, and also couldn't find any code that use them neither.

So now to change speed/scale of Em, just add 0x40 to the first byte of the ESL entry (can usually just set first digit to 4)

With the flag moved that gives us 2 extra bits we can use to add further expansions (eg. the disable-laser-interaction flag suggested by @Mister-Curious, not sure how to implement it yet though)

This also fixes the issue with savegames/checkpoint not keeping the speed/scale reported by @Mister-Curious too, the flag should stay in place between savegames now, so speed/scale should still get updated.

Seems to fix it on my side at least, hoping to hear if it helps for others too, build can be grabbed from https://github.com/nipkownix/re4_tweaks/suites/8155427280/artifacts/354006147