### PR TITLE
Trainer: improve "Disable Enemy Targeting" patch

### DIFF
--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -360,6 +360,29 @@ bool __cdecl DebugTrg_hook(uint32_t flag)
 	return ((Joy[0].trg_18 & JOY_X) != 0); // return true if X was newly pressed
 }
 
+// RouteCkToPos / RouteCkPosToPos hooks: called by enemy pathfinding code, returning false should prevent enemies from targetting the player
+// TODO: should we also set the pDest vec to some value too?
+BOOL(__cdecl* RouteCkToPos)(cEm* pMy, Vec* pPos, Vec* pDest, uint32_t mode, float* pMax);
+BOOL __cdecl RouteCkToPos_Hook(cEm* pMy, Vec* pPos, Vec* pDest, uint32_t mode, float* pMax)
+{
+	// cSubChar/Ashley seems to use this func too, hopefully this check can keep her working
+	// TODO: cRoutine/cRoutineLeon classes also use it, and pl03, not sure if this might break them...
+	if (pMy != AshleyPtr() && pMy != PlayerPtr())
+		if (FlagIsSet(GlobalPtr()->flags_DEBUG_0_60, uint32_t(Flags_DEBUG::DBG_EM_NO_ATK)))
+			return FALSE;
+
+	return RouteCkToPos(pMy, pPos, pDest, mode, pMax);
+}
+
+BOOL(__cdecl* RouteCkPosToPos)(Vec* pPos1, Vec* pPos2, Vec* pDest);
+BOOL __cdecl RouteCkPosToPos_Hook(Vec* pPos1, Vec* pPos2, Vec* pDest)
+{
+	if (FlagIsSet(GlobalPtr()->flags_DEBUG_0_60, uint32_t(Flags_DEBUG::DBG_EM_NO_ATK)))
+		return FALSE;
+
+	return RouteCkPosToPos(pPos1, pPos2, pDest);
+}
+
 void Trainer_DrawDebugTrgHint()
 {
 	if (!bCfgMenuOpen)
@@ -481,6 +504,41 @@ void Trainer_Init()
 		FlagPatch patch_em10FindCk(globals->flags_DEBUG_0_60, uint32_t(Flags_DEBUG::DBG_EM_NO_ATK));
 		patch_em10FindCk.SetPatch((uint8_t*)em10FindCk.as_int(), { 0x31, 0xC0, 0xC3 });
 		flagPatches.push_back(patch_em10FindCk);
+
+		// A ton of Ems use l_pl_378 to check distance from player & begin attacks
+		// This gets set inside emMove func, hook it so we can override it with a massive distance if flag set
+		pattern = hook::pattern("DE C1 D9 9E 78 03 00 00 D9 05");
+		struct emMove_l_pl_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				// Code we replaced
+				uint32_t orig_esi = regs.esi;
+				__asm {
+					mov eax, [orig_esi]
+					fstp dword ptr[eax + 0x378]
+				}
+
+				if (FlagIsSet(GlobalPtr()->flags_DEBUG_0_60, uint32_t(Flags_DEBUG::DBG_EM_NO_ATK)))
+				{
+					cEm* pEm = (cEm*)orig_esi;
+					pEm->l_pl_378 = 1.0e16;
+				}
+			}
+		};
+		injector::MakeInline<emMove_l_pl_hook>(pattern.count(3).get(0).get<uint32_t>(2), pattern.count(3).get(0).get<uint32_t>(8)); // emMove
+		injector::MakeInline<emMove_l_pl_hook>(pattern.count(3).get(1).get<uint32_t>(2), pattern.count(3).get(1).get<uint32_t>(8)); // EmSetFromList2
+		injector::MakeInline<emMove_l_pl_hook>(pattern.count(3).get(2).get<uint32_t>(2), pattern.count(3).get(2).get<uint32_t>(8)); // EmSetEvent
+
+		// Pretty much every Em uses RouteCkToPos to check if player can be routed to, hook it so we can change result if needed
+		pattern = hook::pattern("E8 ? ? ? ? 83 C4 14 85 C0 74 ? 83 8E 08 04");
+		ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), RouteCkToPos);
+		InjectHook(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), RouteCkToPos_Hook);
+
+		// Some Ems (eg. Saddler Em31) use RouteCkPosToPos instead, will need seperate hook...
+		pattern = hook::pattern("E8 ? ? ? ? 83 C4 18 85 C0 74 ? 83 8E 08 04");
+		ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), RouteCkPosToPos);
+		InjectHook(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), RouteCkPosToPos_Hook);
 	}
 
 	// Ashley presence


### PR DESCRIPTION
This improves the "Disable Enemy Targeting" trainer patch by adding some extra hooks for some AI funcs.

Two things are changed here, first I noticed `l_pl_378` was used in Em09 to check distance from player & decide whether to melee/walk/etc based on it, so added something to set that to a high number, seemed to help with a couple more enemies but most were still able to track player fine.
Some other Ems use `RouteCkToPos` & `RouteCkPosToPos` to check if it can pathfind to the player though, for those it seems we can just return false and that stops them from tracking properly.

(there were a couple other non-Em things that used those Route funcs too, but seemed like those could be detected & handled fine)

Need to test this out some more though, the few Ems I checked seemed to stop targeting player fine now, but wouldn't be surprised if some other Ems might not be affected by it..
Would appreciate anyone trying it out, please let me know if you find any Ems that are unaffected, or anything that seems broken with it!

Build can be found at https://github.com/nipkownix/re4_tweaks/suites/9788385305/artifacts/470741553 (patch can be enabled in Trainer -> Patches -> "Disable Enemy Targeting")