### PR TITLE
Misc: add workaround fix for Saddler cutscene item glow issue

### DIFF
--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1468,4 +1468,20 @@ void re4t::init::Misc()
 			}
 		}; injector::MakeInline<listRangeCheck_AllowSkipToBottomFix_LvUpMenu>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(0x14));
 	}
+
+	// HACK: Fix for Saddler item drop appearing before cutscene begins, making the item glow show up through the cutscene
+	// Item gets spawned by em31_R1_Die_Normal when r_no_2 == 4
+	// Some reason r_no_2 gets set to 4 twice, once immediately after death anim, before the cutscene starts (causing the early item spawn)
+	// And then later R332RocketShootEnd calls into cEm31::setDieCancel, which forces r_no_2 to 4 (seems to be part of the cutscene code)
+	// 
+	// We can patch out the first one by removing the r_no_2 increment call inside the r_no_2 == 3 block, which stops it from spawning early
+	// However GC (which doesn't have this issue) still seems to have the increment code, so this likely isn't fixing the root cause, but it's a workaround at least...
+	// Main issue could be the MotionMove check that r_no_2 == 3 runs before incrementing to 4 - maybe that only passed on GC once cutscene was over, but UHD passes immediately
+	// Need to check with GC debug and see if that also calls r_no_2 == 4 twice, and check what moment it actually increments it to 4...
+	// 
+	// More info at https://github.com/nipkownix/re4_tweaks/issues/331
+	{
+		auto pattern = hook::pattern("FE 86 FE 00 00 00 5B 5F 5E 5D C3 DD"); // "inc byte ptr [esi+0FEh]", 4EE833 in 1.1.0
+		injector::MakeNOP(pattern.count(1).get(0).get<uint8_t>(0), 6, true);
+	}
 }


### PR DESCRIPTION
From the comments:
>HACK: Fix for Saddler item drop appearing before cutscene begins, making the item glow show up through the cutscene
>Item gets spawned by em31_R1_Die_Normal when r_no_2 == 4
>Some reason r_no_2 gets set to 4 twice, once immediately after death anim, before the cutscene starts (causing the early item spawn)
>And then later R332RocketShootEnd calls into cEm31::setDieCancel, which forces r_no_2 to 4 (seems to be part of the cutscene code)
 
>We can patch out the first one by removing the r_no_2 increment call inside the r_no_2 == 3 block, which stops it from spawning early
>However GC (which doesn't have this issue) still seems to have the increment code, so this likely isn't fixing the root cause, but it's a workaround at least...
>Main issue could be the MotionMove check that r_no_2 == 3 runs before incrementing to 4 - maybe that only passed on GC once cutscene was over, but UHD passes immediately
>Need to check with GC debug and see if that also calls r_no_2 == 4 twice, and check what moment it actually increments it to 4...

More info at https://github.com/nipkownix/re4_tweaks/issues/331

Should be fine to merge for now, this only patches code related to Saddler, and albert mentioned that it seems to fix it fine - like comment mentions this is more a hack than a fix though, will probably look at GC debug some time to see if I can figure out why that acts differently (might take a while to figure that out though, so probably better to use this fix for now.)

Are there any places in the game where you fight Saddler besides the r332 ending though? This fix is sorta breaking the AI routines, relying on the cutscene after he dies to set them back to `r_no_2 = 4` instead, if there's somewhere you fight him where that cutscene doesn't play afterward it might cause some issue...