### PR TITLE
Added LimitMatildaBurst option

### DIFF
--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -84,6 +84,8 @@ namespace bio4 {
 
 	void(__cdecl* QuakeExec)(uint32_t No, uint32_t Delay, int Time, float Scale, uint32_t Axis);
   
+	bool(__cdecl* joyFireOn)();
+  
 	ID_UNIT* (__thiscall* IDSystem__unitPtr)(IDSystem* thisptr, uint8_t markNo, ID_CLASS classNo);
 };
 
@@ -873,6 +875,10 @@ bool re4t::init::Game()
 	// QuakeExec ptr
 	pattern = hook::pattern("E8 ? ? ? ? 83 C4 14 8B E5 5D");
 	ReadCall(injector::GetBranchDestination(pattern.get_first()).as_int(), bio4::QuakeExec);
+
+	// joyFireOn ptr
+	pattern = hook::pattern("E8 ? ? ? ? 85 C0 74 ? 8B 8E D8 07 00 00 8B 49 34 E8 ? ? ? ? 84 C0 0F ? ? ? ? ? 8B");
+	ReadCall(pattern.count(1).get(0).get<uint8_t>(0), bio4::joyFireOn);
 
 	// SubScreenOpen funcptr
 	pattern = hook::pattern("55 8B EC A1 ? ? ? ? B9 ? ? ? ? 85 88");

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1204,6 +1204,27 @@ void re4t::init::Misc()
 		}; injector::MakeInline<titleAda_resetScrollAdd>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
 	}
 
+	// Limit Matilda to three round bursts once per trigger pull
+	{
+		auto pattern = hook::pattern("E8 ? ? ? ? 85 C0 74 ? 8B 8E D8 07 00 00 8B 49 34 E8 ? ? ? ? 84 C0 0F ? ? ? ? ? 8B");
+		struct wep17_r2_set_LimitMatildaBurst
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				if (re4t::cfg->bLimitMatildaBurst)
+				{
+					regs.ef |= (1 << regs.zero_flag);
+					return;
+				}
+
+				if (bio4::joyFireOn())
+					regs.ef &= ~(1 << regs.zero_flag);
+				else
+					regs.ef |= (1 << regs.zero_flag);
+			}
+		}; injector::MakeInline<wep17_r2_set_LimitMatildaBurst>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
+	}
+
 	// Allow changing games level of violence to users choice
 	{
 		// find cCard functbl (tbl.1654)

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1211,13 +1211,7 @@ void re4t::init::Misc()
 		{
 			void operator()(injector::reg_pack& regs)
 			{
-				if (re4t::cfg->bLimitMatildaBurst)
-				{
-					regs.ef |= (1 << regs.zero_flag);
-					return;
-				}
-
-				if (bio4::joyFireOn())
+				if (!re4t::cfg->bLimitMatildaBurst && bio4::joyFireOn())
 					regs.ef &= ~(1 << regs.zero_flag);
 				else
 					regs.ef |= (1 << regs.zero_flag);

--- a/dllmain/SDK/objWep.h
+++ b/dllmain/SDK/objWep.h
@@ -59,3 +59,8 @@ public:
 	virtual void beginReload() = 0;
 };
 assert_size(cObjWep, 0x76C);
+
+namespace bio4
+{
+	extern bool(__cdecl* joyFireOn)();
+}

--- a/dllmain/SDK/objWep.h
+++ b/dllmain/SDK/objWep.h
@@ -59,8 +59,3 @@ public:
 	virtual void beginReload() = 0;
 };
 assert_size(cObjWep, 0x76C);
-
-namespace bio4
-{
-	extern bool(__cdecl* joyFireOn)();
-}

--- a/dllmain/SDK/pad.h
+++ b/dllmain/SDK/pad.h
@@ -171,4 +171,5 @@ namespace bio4
 {
 	extern bool(__cdecl* KeyOnCheck_0)(KEY_BTN a1);
 	extern void(__cdecl* KeyStop)(uint64_t un_stop_bit);
+	extern bool(__cdecl* joyFireOn)();
 }

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -347,6 +347,7 @@ void re4t_cfg::ReadSettings(std::wstring ini_path)
 	re4t::cfg->bEnableDebugMenu = iniReader.ReadBoolean("MISC", "EnableDebugMenu", re4t::cfg->bEnableDebugMenu);
 	re4t::cfg->bEnableModExpansion = iniReader.ReadBoolean("MISC", "EnableModExpansion", re4t::cfg->bEnableModExpansion);
 	re4t::cfg->bForceETSApplyScale = iniReader.ReadBoolean("MISC", "ForceETSApplyScale", re4t::cfg->bForceETSApplyScale);
+	re4t::cfg->bLimitMatildaBurst = iniReader.ReadBoolean("MISC", "LimitMatildaBurst", re4t::cfg->bLimitMatildaBurst);
 
 	// MEMORY
 	re4t::cfg->bAllowHighResolutionSFD = iniReader.ReadBoolean("MEMORY", "AllowHighResolutionSFD", re4t::cfg->bAllowHighResolutionSFD);
@@ -810,6 +811,7 @@ void WriteSettings(std::wstring iniPath, bool trainerIni)
 	iniReader.WriteBoolean("MISC", "AutomaticMashingQTE", re4t::cfg->bAutomaticMashingQTE);
 	iniReader.WriteBoolean("MISC", "SkipIntroLogos", re4t::cfg->bSkipIntroLogos);
 	iniReader.WriteBoolean("MISC", "SkipMenuFades", re4t::cfg->bSkipMenuFades);
+	iniReader.WriteBoolean("MISC", "LimitMatildaBurst", re4t::cfg->bLimitMatildaBurst);
 	iniReader.WriteBoolean("MISC", "EnableDebugMenu", re4t::cfg->bEnableDebugMenu);
 	// Not writing EnableModExpansion / ForceETSApplyScale back to users INI in case those were enabled by a mod override INI (which the user might want to remove later)
 	// We don't have any UI options for those anyway, so pointless for us to write it back
@@ -987,6 +989,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "EnableDebugMenu", re4t::cfg->bEnableDebugMenu ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableModExpansion", re4t::cfg->bEnableModExpansion ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ForceETSApplyScale", re4t::cfg->bForceETSApplyScale ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "LimitMatildaBurst", re4t::cfg->bLimitMatildaBurst ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 
 	// MEMORY

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -133,6 +133,7 @@ public:
 	bool bEnableDebugMenu = false;
 	bool bEnableModExpansion = false;
 	bool bForceETSApplyScale = false;
+	bool bLimitMatildaBurst = false;
 
 	// MEMORY
 	bool bAllowHighResolutionSFD = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1489,6 +1489,18 @@ void cfgMenuRender()
 						ImGui::TextWrapped("(will only take effect when SkipIntroLogos is also set to true)");
 					}
 
+					// LimitMatildaBurst
+					{
+						ImGui_ColumnSwitch();
+
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("LimitMatildaBurst", &re4t::cfg->bLimitMatildaBurst);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Limit the Matilda to one three round burst per trigger pull.");
+					}
+
 					// EnableDebugMenu
 					{
 						ImGui_ColumnSwitch();

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -328,6 +328,9 @@ SkipIntroLogos = false
 ; (will only take effect when SkipIntroLogos is also set to true)
 SkipMenuFades = false
 
+; Limit the Matilda to one three round burst per trigger pull.
+LimitMatildaBurst = false
+
 ; Enables the "tool menu" debug menu, present inside the game but unused, and adds a few custom menu entries ("SAVE GAME", "DOF/BLUR MENU", etc).
 ; Can be opened with the LT+LS button combination (or CTRL+F3 by default on keyboard).
 ; If enabled on the 1.0.6 debug build it'll apply some fixes to the existing debug menu, fixing AREA JUMP etc, but won't add our custom entries due to lack of space.


### PR DESCRIPTION
https://github.com/nipkownix/re4_tweaks/issues/249
I saw this suggestion and thought it was a good idea. This makes the Matilda feel a lot better when using type II/III config controls, as it's much harder to consistently control the rate of fire when using analog triggers. I suspect that's why RE4VR made this change as well.

(My dream would be if we could one day break the Matilda and its stock up into two items, so we could configure it RE2-style with semi-auto and burst modes)

~On second thought, maybe this option should just be something that forces `joyFireOn` to return false for every weapon, to be consistent. Let me know what you guys think.~
Edit: Hmm, I tried adding a universal semi-auto trigger for the other weapons, and it just doesn't feel good whenever you pull the trigger faster than the firing delay will allow you to shoot. It's fine with the Matilda though, since it has virtually no firing delay.

Edit2: Another option I've come up with is to only repeat fire when the right trigger is fully depressed. I still think I prefer this option, but that also feels way better than the default.