### PR TITLE
OverrideDifficulty: support skipping the difficulty menu when playing in Japanese

### DIFF
--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1241,10 +1241,6 @@ void re4t::init::Misc()
 
 		// Patches for Japanese language support (language_8 == 0):
 
-		// ignore language_8 check when skipping the difficulty menu
-		pattern = hook::pattern("38 59 08 0F 84 09 0B 00 00");
-		injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(3), 6); // titleMain
-
 		// repurpose the hide Professional mode block to hide Amateur mode instead
 		pattern = hook::pattern("C7 46 30 01 00 00 00");
 		injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(7), 2); // titleLevelInit

--- a/dllmain/TitleMenu.cpp
+++ b/dllmain/TitleMenu.cpp
@@ -140,6 +140,10 @@ void re4t::init::TitleMenu()
 					regs.eax = TTL_CMD_LEVEL;
 			}
 		}; injector::MakeInline<titleMenuSelect_SkipLevelSelect>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
+
+		// Japanese: ignore language_8 check in the TTL_CMD_START case
+		pattern = hook::pattern("38 59 08 0F 84 09 0B 00 00");
+		injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(3), 6); // titleMain
 	}
 
 	// Add Professional mode select to Separate Ways


### PR DESCRIPTION
Woops, just noticed that I needed to move this out of the NTSC mode block as well, otherwise trying to skip the difficulty menu in Japanese does nothing.