### PR TITLE
Rewrite FixDisplayMode

### DIFF
--- a/dllmain/D3D9hook.cpp
+++ b/dllmain/D3D9hook.cpp
@@ -189,6 +189,8 @@ HRESULT hook_Direct3D9::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND h
 	// Force v-sync off
 	if (re4t::cfg->bDisableVsync)
 		pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+	else
+		pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_ONE;
 
 	IDirect3DDevice9* device = nullptr;
 
@@ -306,6 +308,8 @@ HRESULT hook_Direct3DDevice9::Reset(D3DPRESENT_PARAMETERS* pPresentationParamete
 	// Force v-sync off
 	if (re4t::cfg->bDisableVsync)
 		pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+	else
+		pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_ONE;
 
 	ImGui_ImplDX9_InvalidateDeviceObjects(); // Reset ImGui objects to prevent freezing
 

--- a/dllmain/DisplayModeFix.cpp
+++ b/dllmain/DisplayModeFix.cpp
@@ -1,0 +1,344 @@
+#include <iostream>
+#include "dllmain.h"
+#include "ConsoleWnd.h"
+#include "Game.h"
+#include "Settings.h"
+
+int iDesiredRefreshRate = 0;
+
+struct GX_DisplayMode
+{
+	int width;
+	int height;
+	int refreshRate;
+};
+
+void FillDisplayModeVector(std::vector<GX_DisplayMode> *vect, bool OnlyHighestRefreshRates)
+{
+	std::vector<GX_DisplayMode> modes;
+
+	DEVMODE devMode = {};
+	ZeroMemory(&devMode, sizeof(DEVMODE));
+	devMode.dmSize = sizeof(DEVMODE);
+
+	HMONITOR primaryMonitor = MonitorFromPoint({ 0, 0 }, MONITOR_DEFAULTTOPRIMARY);
+
+	MONITORINFOEXW monInfo = {};
+	monInfo.cbSize = sizeof(monInfo);
+	if (!GetMonitorInfoW(primaryMonitor, reinterpret_cast<MONITORINFO*>(&monInfo)))
+	{
+		spd::log()->info("{} -> Failed to query monitor info!", __FUNCTION__);
+	}
+
+	// Get all display modes from primary monitor
+	int modeNum = 0;
+	while (EnumDisplaySettingsW(monInfo.szDevice, modeNum, &devMode))
+	{
+		modes.push_back({ int(devMode.dmPelsWidth), int(devMode.dmPelsHeight), int(devMode.dmDisplayFrequency) });
+		modeNum++;
+	}
+
+	// Sort display modes by resolution and refresh rate
+	std::sort(modes.begin(), modes.end(), [](const GX_DisplayMode& lhs, const GX_DisplayMode& rhs)
+		{
+			if (lhs.width != rhs.width) return lhs.width < rhs.width;
+			if (lhs.height != rhs.height) return lhs.height < rhs.height;
+			return lhs.refreshRate < rhs.refreshRate; // Keep the lowest refresh rate
+		});
+
+	// Filter display modes
+	std::vector<GX_DisplayMode> filteredModes;
+	filteredModes.reserve(modes.size());
+
+	GX_DisplayMode prevMode = {};
+	for (const GX_DisplayMode& mode : modes)
+	{
+		if (mode.width != prevMode.width || mode.height != prevMode.height)
+		{
+			// This is a unique resolution, so add it to the filtered list
+			filteredModes.push_back(mode);
+		}
+		else
+		{
+			if (!OnlyHighestRefreshRates)
+			{
+				// Duplicate resolution, but we'll populate every refresh rate available for each unique resolution
+				if (mode.refreshRate != prevMode.refreshRate)
+				{
+					filteredModes.push_back(mode);
+				}
+			}
+			else
+			{
+				// Duplicate resolution, only keep the highest refresh rate for this resolution
+				if (mode.refreshRate > prevMode.refreshRate)
+				{
+					filteredModes.back() = mode;
+				}
+			}
+		}
+
+		prevMode = mode;
+	}
+
+	modes = std::move(filteredModes);
+
+	// Log the display modes used
+	if (re4t::cfg->bVerboseLog)
+	{
+		spd::log()->info("+-----------------+-----------------+");
+		spd::log()->info("| FillDisplayModeVector: modes      |");
+		spd::log()->info("+-----------------+-----------------+");
+		spd::log()->info("+ Primary monitor: {:<16} +", WstrToStr(monInfo.szDevice));
+		spd::log()->info("+-----------------+-----------------+");
+		spd::log()->info("+ OnlyHighestRefreshRates = {:<11} +", OnlyHighestRefreshRates ? "true" : "false");
+		spd::log()->info("+-----------------+-----------------+");
+		for (const GX_DisplayMode& mode : modes)
+		{
+			spd::log()->info("| {:<5}x {:<5} {:>17} Hz |", mode.width, mode.height, mode.refreshRate);
+		}
+		spd::log()->info("+-----------------+-----------------+");
+	}
+
+	// Move values into vector
+	*vect = std::move(modes);
+
+	return;
+}
+
+char __cdecl D3D_FillDisplayModeVector_hook(std::vector<GX_DisplayMode>* vect, bool checkWidthHeightCombinations)
+{
+	UNREFERENCED_PARAMETER(checkWidthHeightCombinations);
+
+	FillDisplayModeVector(vect, re4t::cfg->bOnlyShowHighestRefreshRates);
+	return 0;
+}
+
+int sprintfCurrentHz = 0; // Filled in res_sprintf_getCurRefreshRate_hook
+int sprintf_1_hook(char* Buffer, char* Format, ...)
+{
+	va_list args;
+	va_start(args, Format);
+	int result = vsprintf(Buffer, Format, args);
+	va_end(args);
+
+	// Append refresh rate for current resolution
+	std::string hzStr = " " + std::to_string(sprintfCurrentHz) + " Hz";
+	strcat(Buffer, hzStr.c_str());
+
+	// Update iDesiredRefreshRate so our hooks know what is the refesh rate
+	// of the resolution that is currently selected
+	iDesiredRefreshRate = sprintfCurrentHz;
+
+	return result;
+}
+
+void re4t::init::DisplayModeFix()
+{
+	// Game is hardcoded to only allow 60Hz display modes for some reason...
+	if (re4t::cfg->bFixDisplayMode)
+	{
+		// Replace function that fills resolution list, normally it filters resolutions to only 60Hz modes, which is bad for non-60Hz players...
+		// We now reimplement the entire function and use EnumDisplaySettings to get a list of all resolutions available, avoiding duplicates and only
+		// showing the highest refresh rate for each unique width and height, if needed.
+		// Using EnumDisplaySettings is what DXVK does as well, so this should hopefully be fine.
+		auto pattern = hook::pattern("E8 ? ? ? ? A1 ? ? ? ? 83 C4 08 3B C7");
+		auto ptr_D3D_FillDisplayModeVector = injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int();
+		InjectHook(ptr_D3D_FillDisplayModeVector, D3D_FillDisplayModeVector_hook);
+
+		// Hook D3D_GetDisplayModeForWidthHeight to manipulate its filter, so we can use our own refresh rate instead.
+		// This function was originally only capable of returning 60 Hz resolutions, which is quite an oversight on QLOC's part.
+		pattern = hook::pattern("8B 45 ? 83 F8 ? 75 ? 8B 4D ? 8B 7D ? 3B 4D");
+		struct D3D_GetDisplayModeForWidthHeight_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				assert(iDesiredRefreshRate != 0);
+
+				regs.eax = iDesiredRefreshRate;
+				regs.ef |= (1 << regs.zero_flag);
+			}
+		}; injector::MakeInline<D3D_GetDisplayModeForWidthHeight_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
+
+		// Hook GXInit_Impl right after the game calls ConfigReadINI() so we can determine which refresh rate the game should
+		// use on startup based on what is stored in it's config.ini.
+		pattern = hook::pattern("8B 85 ? ? ? ? 8B 8D ? ? ? ? 8D 95 ? ? ? ? 52 50 51 E8 ? ? ? ? 83 C4");
+		struct StartupRefreshRate_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				// Code we replaced
+				regs.eax = *(uint32_t*)(regs.ebp - 0x8B8);
+
+				int iRefreshRate = 0;
+
+				// Get vector of all display modes
+				std::vector<GX_DisplayMode> dispModeVec;
+				FillDisplayModeVector(&dispModeVec, false);
+
+				// Get desired resolution and refresh rate from the game's config.ini
+				GX_DisplayMode targetMode = { g_INIConfig()->resolutionWidth, g_INIConfig()->resolutionHeight, g_INIConfig()->resolutionRefreshRate };
+
+				spd::log()->info("FixDisplayMode -> Checking if display mode \"{}x{} @ {} Hz\" is supported by the primary monitor...", targetMode.width, targetMode.height, targetMode.refreshRate);
+
+				// Check if this mode is supported by the current primary display
+				auto it = std::find_if(dispModeVec.begin(), dispModeVec.end(), [&](const GX_DisplayMode& mode)
+					{
+						return mode.width == targetMode.width && mode.height == targetMode.height && mode.refreshRate == targetMode.refreshRate;
+					});
+
+				// Display mode is supported, proceed
+				if (it != dispModeVec.end())
+				{
+					spd::log()->info("FixDisplayMode -> Display mode is supported, proceeding...");
+					iRefreshRate = g_INIConfig()->resolutionRefreshRate;
+				}
+				else // Display mode is not supported, try to use the desktop's instead
+				{
+					spd::log()->info("FixDisplayMode -> Display mode specified in the game's config.ini file isn't supported by the primary monitor!");
+					spd::log()->info("FixDisplayMode -> Trying to use the current desktop resolution instead...");
+
+					// Get the current refresh rate from Windows
+					DEVMODE devMode = {};
+					ZeroMemory(&devMode, sizeof(DEVMODE));
+					devMode.dmSize = sizeof(DEVMODE);
+
+					HMONITOR primaryMonitor = MonitorFromPoint({ 0, 0 }, MONITOR_DEFAULTTOPRIMARY);
+
+					MONITORINFOEXW monInfo = {};
+					monInfo.cbSize = sizeof(monInfo);
+					if (!GetMonitorInfoW(primaryMonitor, reinterpret_cast<MONITORINFO*>(&monInfo)))
+					{
+						spd::log()->info("FixDisplayMode -> Failed to query monitor info!");
+					}
+
+					if (!EnumDisplaySettingsW(monInfo.szDevice, ENUM_CURRENT_SETTINGS, &devMode))
+					{
+						#ifdef VERBOSE
+						con.log("Couldn't read the display refresh rate. Using fallback value.");
+						#endif
+
+						spd::log()->info("FixDisplayMode -> Couldn't read the display refresh rate. Using \"60\" as fallback value.");
+
+						iRefreshRate = 60; // Fallback value.
+					}
+					else
+					{
+						#ifdef VERBOSE
+						con.log("Primary display device name: %s", WstrToStr(monInfo.szDevice).c_str());
+						#endif
+
+						spd::log()->info("FixDisplayMode -> Primary display device name: {}", WstrToStr(monInfo.szDevice));
+
+						iRefreshRate = devMode.dmDisplayFrequency;
+
+						// Replace game's current display mode with the one from the desktop
+						g_INIConfig()->resolutionWidth = devMode.dmPelsWidth;
+						g_INIConfig()->resolutionHeight = devMode.dmPelsHeight;
+						g_INIConfig()->resolutionRefreshRate = iRefreshRate;
+
+						regs.eax = devMode.dmPelsHeight; // Height param that will be passed to the next function call
+					}
+				}
+
+				spd::log()->info("FixDisplayMode -> Starting game with a refresh rate of {} Hz", iRefreshRate);
+
+				#ifdef VERBOSE
+				con.log("New refresh rate = %d", iRefreshRate);
+				#endif
+
+				// Save chosen refresh rate
+				iDesiredRefreshRate = iRefreshRate;
+			}
+		}; injector::MakeInline<StartupRefreshRate_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
+
+		// Hook D3D_SetupPresentationGlobals
+		pattern = hook::pattern("89 35 ? ? ? ? 89 15 ? ? ? ? A3 ? ? ? ? 89");
+		struct D3D_SetupPresentationGlobals_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				// If we don't update g_D3D_RefreshRate and regs.esi (RefreshRate param passed to this func) here,
+				// g_D3DPresentParams's FullScreen_RefreshRateInHz will not be updated when changing resolutions through the game's config menu.
+				*bio4::g_D3D::RefreshRate = iDesiredRefreshRate;
+				regs.esi = iDesiredRefreshRate;
+			}
+		}; injector::MakeInline<D3D_SetupPresentationGlobals_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));	
+		
+		// Hook OptionScreen::init to also take g_D3D_RefreshRate into consideration when initiating g_GfxSettings_ResolutionIdx
+		pattern = hook::pattern("8B 15 ? ? ? ? 3B 14 ? 75 ? 8B 15 ? ? ? ? 3B 54 38");
+		struct OptionScreen__init_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				regs.edx = *bio4::g_D3D::Width_1;
+
+				int curRefreshRate = *(uint32_t*)(regs.eax + regs.edi + 8);
+
+				if (curRefreshRate != *bio4::g_D3D::RefreshRate)
+					regs.edx = 0; // Easy way to make the game fail the check and move to the next resolution in the list...
+			}
+		}; injector::MakeInline<OptionScreen__init_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
+
+		// Hook sprinf_1 call inside graphics_menu so we can also display the refresh rate next to the resolution
+		pattern = hook::pattern("E8 ? ? ? ? 8B 35 ? ? ? ? 83 C4 10 85 F6");
+		InjectHook(pattern.count(1).get(0).get<uint32_t>(0), sprintf_1_hook);
+
+		// Hook just before the previous sprinf_1 call to store the refresh rate of the currently shown/selected resolution
+		pattern = hook::pattern("8B 48 04 8B 10 51 52 68 ? ? ? ? 68 ? ? ? ? E8");
+		struct res_sprintf_getCurRefreshRate_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				// Code we replaced
+				regs.edx = *(uint32_t*)(regs.eax);
+				regs.ecx = *(uint32_t*)(regs.eax + 0x4);
+
+				// Save refresh rate for this resolution
+				sprintfCurrentHz = *(uint32_t*)(regs.eax + 0x8);
+			}
+		}; injector::MakeInline<res_sprintf_getCurRefreshRate_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
+
+		// Hook ConfigWriteINI to make sure the current resolution is being saved correctly
+		pattern = hook::pattern("8B 4E ? 8B 56 ? 8B 06 51 8B 8D ? ? ? ? 52 50 68");
+		struct WriteIniHook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				regs.eax = *bio4::g_D3D::Width_1;
+				regs.edx = *bio4::g_D3D::Height_1;
+				regs.ecx = *bio4::g_D3D::RefreshRate;
+			}
+		}; injector::MakeInline<WriteIniHook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(8));
+
+		// Log display modes for troubleshooting
+		if (re4t::cfg->bVerboseLog)
+		{
+			DISPLAY_DEVICE device;
+			ZeroMemory(&device, sizeof(DISPLAY_DEVICE));
+			device.cb = sizeof(DISPLAY_DEVICE);
+
+			DEVMODE devMode = {};
+			ZeroMemory(&devMode, sizeof(DEVMODE));
+			devMode.dmSize = sizeof(DEVMODE);
+
+			spd::log()->info("+-----------------+-----------------+");
+			spd::log()->info("| Display modes                     |");
+			spd::log()->info("+-----------------+-----------------+");
+			int devIndex = 0;
+			while (EnumDisplayDevicesW(NULL, devIndex, &device, 0))
+			{
+				// Enumerate all of the display settings for the current display
+				int setIndex = 0;
+				while (EnumDisplaySettingsExW(device.DeviceName, setIndex, &devMode, 0))
+				{
+					spd::log()->info("| {:<12}: {:<5}x {:<5} {:>3} Hz |", WstrToStr(device.DeviceName), devMode.dmPelsWidth, devMode.dmPelsHeight, devMode.dmDisplayFrequency);
+
+					setIndex++;
+				}
+				devIndex++;
+			}
+			spd::log()->info("+-----------------+-----------------+");
+		}
+	}
+}

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -6,8 +6,6 @@
 #include "Settings.h"
 #include <timeapi.h>
 
-int g_UserRefreshRate;
-
 uintptr_t ptrGXCopyTex;
 uintptr_t ptrAfterItemExamineHook;
 uintptr_t ptrFilter03;
@@ -103,7 +101,7 @@ void Framelimiter_Hook(uint8_t isAliveEvt_result)
 		framelimiterInited = true;
 	}
 
-	int gameFramerate = GameVariableFrameRate();
+	int gameFramerate = GetGameVariableFrameRate();
 
 	// The games IsAliveEvt check seems to (indirectly) result in framelimiter loop limiting to 60FPS
 	// maybe a remnant of some time when more framerate options were available?
@@ -272,6 +270,8 @@ void re4t::init::MultithreadFix()
 
 void re4t::init::DisplayTweaks()
 {
+	re4t::init::DisplayModeFix();
+
 	// Implements new reduced-CPU-usage limiter
 	if (re4t::cfg->bReplaceFramelimiter)
 	{
@@ -344,103 +344,6 @@ void re4t::init::DisplayTweaks()
 		}; injector::MakeInline<WriteIniHook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(9));
 
 		spd::log()->info("Vsync disabled");
-	}
-
-	// Game is hardcoded to only allow 60Hz display modes for some reason...
-	// Hook func that runs EnumAdapterModes & checks for 60Hz modes, make it use the refresh rate from Windows instead
-	if (re4t::cfg->bFixDisplayMode)
-	{
-		if (re4t::cfg->iCustomRefreshRate > -1)
-		{
-			g_UserRefreshRate = re4t::cfg->iCustomRefreshRate;
-		}
-		else
-		{
-			DISPLAY_DEVICE device{ 0 };
-			device.cb = sizeof(DISPLAY_DEVICE);
-			DEVMODE lpDevMode{ 0 };
-			if (EnumDisplayDevices(NULL, 0, &device, 0) == false ||
-				EnumDisplaySettings(device.DeviceName, ENUM_CURRENT_SETTINGS, &lpDevMode) == false)
-			{
-				#ifdef VERBOSE
-				con.log("Couldn't read the display refresh rate. Using fallback value.");
-				#endif
-
-				spd::log()->info("FixDisplayMode -> Couldn't read the display refresh rate. Using fallback value.");
-
-				g_UserRefreshRate = 60; // Fallback value.
-			}
-			else
-			{
-				#ifdef VERBOSE
-				con.log("Device 0 name: %s", device.DeviceName);
-				#endif
-				g_UserRefreshRate = lpDevMode.dmDisplayFrequency;
-
-				// Log display modes for troubleshooting
-				if (re4t::cfg->bVerboseLog)
-				{
-					DEVMODE dm = { 0 };
-					dm.dmSize = sizeof(dm);
-					spd::log()->info("+----------+----------+");
-					spd::log()->info("| Display modes       |");
-					spd::log()->info("+----------+----------+");
-					for (int iModeNum = 0; EnumDisplaySettings(device.DeviceName, iModeNum, &dm) != 0; iModeNum++)
-					{
-						spd::log()->info("| {:<5}x {:<5} {:>3} Hz |", dm.dmPelsWidth, dm.dmPelsHeight, dm.dmDisplayFrequency);
-					}
-					spd::log()->info("+----------+----------+");
-				}
-			}
-		}
-
-		#ifdef VERBOSE
-		con.log("New refresh rate = %d", g_UserRefreshRate);
-		#endif
-
-		spd::log()->info("FixDisplayMode -> New refresh rate = {}", g_UserRefreshRate);
-
-		auto pattern = hook::pattern("8B 45 ? 83 F8 ? 75 ? 8B 4D ? 8B 7D ? 3B 4D");
-		struct DisplayModeFix
-		{
-			void operator()(injector::reg_pack& regs)
-			{
-				regs.eax = g_UserRefreshRate;
-				regs.ef |= (1 << regs.zero_flag);
-			}
-		}; injector::MakeInline<DisplayModeFix>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
-
-		// Patch function that fills resolution list, normally it filters resolutions to only 60Hz modes, which is bad for non-60Hz players...
-		// Changing it to check for desktop refresh-rate helped, but unfortunately D3D doesn't always match desktop refresh rate
-		// Luckily it turns out this function has an unused code-path which filters by checking for duplicate width/height combos instead, so any refresh rate can be allowed
-		// who knows why they chose not to use it...
-		pattern = hook::pattern("81 FA 98 26 00 00 77 ? 38 45 ? 75 ?");
-		injector::WriteMemory(pattern.count(1).get(0).get<uint8_t>(11), uint8_t(0xEB), true);
-
-		// Patch above function to only allow 59Hz+ modes
-		// (workaround for game potentially displaying invalid modes that some displays expose)
-		struct DisplayModeFilter
-		{
-			void operator()(injector::reg_pack& regs)
-			{
-				const int GameMaxHeight = 10480 - 600; // game does strange optimized check involving 600 taken away from edx...
-
-				// Game does JA after the CMP we patched, so we set ZF and CF both to 1 here
-				// then if we want game to take the JA, we clear them both
-				regs.ef |= (1 << regs.zero_flag);
-				regs.ef |= (1 << regs.carry_flag);
-
-				// Make game skip any mode under 59, since they're likely invalid
-				// (old game code would only accept 60Hz modes, so I think this is fine for us to do)
-				int refreshRate = *(int*)(regs.ebp - 0xC);
-				if (regs.edx > GameMaxHeight || refreshRate < 59)
-				{
-					// Clear both flags to make game take JA and skip this mode
-					regs.ef &= ~(1 << regs.zero_flag);
-					regs.ef &= ~(1 << regs.carry_flag);
-				}
-			}
-		}; injector::MakeInline<DisplayModeFilter>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
 	}
 
 	// Apply window changes

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -121,7 +121,11 @@ namespace bio4 {
 		uint32_t* RefreshRate = nullptr;
 		uint32_t* Width_1 = nullptr;
 		uint32_t* Height_1 = nullptr;
+		bool* Fullscreen = nullptr;
 	}
+
+	void(__cdecl* D3D_SetupResolution)(int Width, int Height);
+	void(__cdecl* ScreenReSize)(int Width, int Height);
 };
 
 // Current play time (H, M, S)
@@ -1232,6 +1236,16 @@ bool re4t::init::Game()
 	pattern = hook::pattern("8B 15 ? ? ? ? 3B 14 ? 75 ? 8B 15 ? ? ? ? 3B 54 38");
 	bio4::g_D3D::Width_1 = (uint32_t*)*pattern.count(1).get(0).get<uint32_t>(2);
 	bio4::g_D3D::Height_1 = bio4::g_D3D::Width_1 + 1;
+	
+	pattern = hook::pattern("38 1D ? ? ? ? 74 0C BE ? ? ? ? BF ? ? ? ? EB 1F 8B 15 ? ? ? ? 6A 40 51 50 53");
+	bio4::g_D3D::Fullscreen = (bool*)*pattern.count(1).get(0).get<uint32_t>(2);
+
+	// Pointer to D3D_SetupResolution
+	pattern = hook::pattern("E8 ? ? ? ? 68 ? ? ? ? 68 ? ? ? ? E8 ? ? ? ? 83 C4 ? E8 ? ? ? ? 83 C0 ? 50 E8 ? ? ? ? 8B 0E");
+	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), bio4::D3D_SetupResolution);
+
+	// Pointer to D3D_SetupResolution
+	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(15)).as_int(), bio4::ScreenReSize);
 
 	// Store current game time that's being calculated inside GetGameTime
 	pattern = hook::pattern("8B 55 ? 8B 45 ? 51 8B 4D ? 52 50 51 68");

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -26,6 +26,28 @@
 #include "SDK/GX.h"
 #include "SDK/gc_math.h"
 
+struct INIConfig
+{
+	int resolutionWidth;
+	int resolutionHeight;
+	int resolutionRefreshRate;
+	int vsync;
+	int fullscreen;
+	int adapter;
+	int shadowQuality;
+	int motionblurEnabled;
+	int ppEnabled;
+	int useHDTexture;
+	int antialiasing;
+	int anisotropy;
+	int variableframerate;
+	int subtitle;
+	int laserR;
+	int laserG;
+	int laserB;
+	int laserA;
+};
+
 struct __declspec(align(4)) DAMAGE {
 	uint8_t unk0[0x40];
 	uint32_t knife40; // 200 
@@ -42,7 +64,9 @@ extern SND_CTRL* Snd_ctrl_work;
 std::string GameVersion();
 extern int iCurPlayTime[3];
 bool GameVersionIsDebug();
-int GameVariableFrameRate();
+int GetGameVariableFrameRate();
+void SetGameVariableFrameRate(int newRate);
+INIConfig* g_INIConfig();
 int CurrentFrameRate();
 InputDevices LastUsedDevice();
 bool isController();
@@ -90,4 +114,10 @@ namespace bio4
 	extern uint8_t(__cdecl* WeaponId2WeaponNo)(ITEM_ID item_id);
 
 	extern void(__cdecl* SceSleep)(uint32_t ctr);
+
+	namespace g_D3D {
+		extern uint32_t* RefreshRate;
+		extern uint32_t* Width_1;
+		extern uint32_t* Height_1;
+	}
 }

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -119,5 +119,9 @@ namespace bio4
 		extern uint32_t* RefreshRate;
 		extern uint32_t* Width_1;
 		extern uint32_t* Height_1;
+		extern bool* Fullscreen;
 	}
+
+	extern void(__cdecl* D3D_SetupResolution)(int Width, int Height);
+	extern void(__cdecl* ScreenReSize)(int Width, int Height);
 }

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -6,8 +6,6 @@
 #include "Settings.h"
 #include "input.hpp"
 
-static uint32_t* ptrGameFrameRate;
-
 // Trainer.cpp externs
 extern std::optional<uint32_t> FlagsExtraValue;
 
@@ -991,7 +989,6 @@ void re4t::init::Misc()
 	{
 		// Hook function to read the FPS value from config.ini
 		auto pattern = hook::pattern("89 0D ? ? ? ? 0F 95 ? 88 15 ? ? ? ? D9 1D ? ? ? ? A3 ? ? ? ? DB 46 ? D9 1D ? ? ? ? 8B 4E ? 89 0D ? ? ? ? 8B 4D ? 5E");
-		ptrGameFrameRate = *pattern.count(1).get(0).get<uint32_t*>(2);
 		struct ReadFPS
 		{
 			void operator()(injector::reg_pack& regs)
@@ -1020,11 +1017,11 @@ void re4t::init::Misc()
 					MessageBoxA(NULL, Msg.c_str(), "re4_tweaks", MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND);
 
 					// Use new FPS value
-					*(int32_t*)(ptrGameFrameRate) = intNewFPS;
+					SetGameVariableFrameRate(intNewFPS);
 				}
 				else {
 					// Use .ini FPS value.
-					*(int32_t*)(ptrGameFrameRate) = intIniFPS;
+					SetGameVariableFrameRate(intIniFPS);
 				}
 			}
 		}; injector::MakeInline<ReadFPS>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));

--- a/dllmain/Patches.h
+++ b/dllmain/Patches.h
@@ -22,6 +22,7 @@ namespace re4t
 		void ConsoleWnd();
 		void D3D9Hook();
 		void DebugDisplay();
+		void DisplayModeFix();
 		void DisplayTweaks();
 		void ExceptionHandler();
 		void FrameRateFixes();

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -130,7 +130,7 @@ void ReadSettingsIni(std::wstring ini_path)
 
 		re4t::cfg->bFixDPIScale = ini.getBool("DISPLAY", "FixDPIScale", re4t::cfg->bFixDPIScale);
 		re4t::cfg->bFixDisplayMode = ini.getBool("DISPLAY", "FixDisplayMode", re4t::cfg->bFixDisplayMode);
-		re4t::cfg->iCustomRefreshRate = ini.getInt("DISPLAY", "CustomRefreshRate", re4t::cfg->iCustomRefreshRate);
+		re4t::cfg->bOnlyShowHighestRefreshRates = ini.getBool("DISPLAY", "OnlyShowHighestRefreshRates", re4t::cfg->bOnlyShowHighestRefreshRates);
 		re4t::cfg->bOverrideLaserColor = ini.getBool("DISPLAY", "OverrideLaserColor", re4t::cfg->bOverrideLaserColor);
 		re4t::cfg->bRainbowLaser = ini.getBool("DISPLAY", "RainbowLaser", re4t::cfg->bRainbowLaser);
 
@@ -600,7 +600,7 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 		ini.setBool("DISPLAY", "Remove16by10BlackBars", re4t::cfg->bRemove16by10BlackBars);
 		ini.setBool("DISPLAY", "FixDPIScale", re4t::cfg->bFixDPIScale);
 		ini.setBool("DISPLAY", "FixDisplayMode", re4t::cfg->bFixDisplayMode);
-		ini.setInt("DISPLAY", "CustomRefreshRate", re4t::cfg->iCustomRefreshRate);
+		ini.setBool("DISPLAY", "OnlyShowHighestRefreshRates", re4t::cfg->bOnlyShowHighestRefreshRates);
 		ini.setBool("DISPLAY", "OverrideLaserColor", re4t::cfg->bOverrideLaserColor);
 		ini.setBool("DISPLAY", "RainbowLaser", re4t::cfg->bRainbowLaser);
 
@@ -936,7 +936,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "Remove16by10BlackBars", re4t::cfg->bRemove16by10BlackBars ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDPIScale", re4t::cfg->bFixDPIScale ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDisplayMode", re4t::cfg->bFixDisplayMode ? "true" : "false");
-	spd::log()->info("| {:<30} | {:>15} |", "CustomRefreshRate", re4t::cfg->iCustomRefreshRate);
+	spd::log()->info("| {:<30} | {:>15} |", "OnlyShowHighestRefreshRates", re4t::cfg->bOnlyShowHighestRefreshRates ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "OverrideLaserColor", re4t::cfg->bOverrideLaserColor ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "RainbowLaser", re4t::cfg->bRainbowLaser ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "LaserR", re4t::cfg->iLaserR);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -165,6 +165,7 @@ void ReadSettingsIni(std::wstring ini_path)
 
 		re4t::cfg->bEnableGCScopeBlur = ini.getBool("DISPLAY", "EnableGCScopeBlur", re4t::cfg->bEnableGCScopeBlur);
 		re4t::cfg->bWindowBorderless = ini.getBool("DISPLAY", "WindowBorderless", re4t::cfg->bWindowBorderless);
+		re4t::cfg->bEnableWindowResize = ini.getBool("DISPLAY", "EnableWindowResize", re4t::cfg->bEnableWindowResize);
 		re4t::cfg->iWindowPositionX = ini.getInt("DISPLAY", "WindowPositionX", re4t::cfg->iWindowPositionX);
 		re4t::cfg->iWindowPositionY = ini.getInt("DISPLAY", "WindowPositionY", re4t::cfg->iWindowPositionY);
 		re4t::cfg->bRememberWindowPos = ini.getBool("DISPLAY", "RememberWindowPos", re4t::cfg->bRememberWindowPos);
@@ -622,6 +623,7 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 
 		ini.setBool("DISPLAY", "EnableGCScopeBlur", re4t::cfg->bEnableGCScopeBlur);
 		ini.setBool("DISPLAY", "WindowBorderless", re4t::cfg->bWindowBorderless);
+		ini.setBool("DISPLAY", "EnableWindowResize", re4t::cfg->bEnableWindowResize);
 		ini.setInt("DISPLAY", "WindowPositionX", re4t::cfg->iWindowPositionX);
 		ini.setInt("DISPLAY", "WindowPositionY", re4t::cfg->iWindowPositionY);
 		ini.setBool("DISPLAY", "RememberWindowPos", re4t::cfg->bRememberWindowPos);
@@ -956,6 +958,7 @@ void re4t_cfg::LogSettings()
 
 	spd::log()->info("| {:<30} | {:>15} |", "EnableGCScopeBlur", re4t::cfg->bEnableGCScopeBlur ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "WindowBorderless", re4t::cfg->bWindowBorderless ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "EnableWindowResize", re4t::cfg->bEnableWindowResize ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "WindowPositionX", re4t::cfg->iWindowPositionX);
 	spd::log()->info("| {:<30} | {:>15} |", "WindowPositionY", re4t::cfg->iWindowPositionY);
 	spd::log()->info("| {:<30} | {:>15} |", "RememberWindowPos", re4t::cfg->bRememberWindowPos ? "true" : "false");

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -51,6 +51,7 @@ public:
 	bool bUseEnhancedGCBlur = true;
 	bool bEnableGCScopeBlur = true;
 	bool bWindowBorderless = false;
+	bool bEnableWindowResize = false;
 	int iWindowPositionX = -1;
 	int iWindowPositionY = -1;
 	bool bRememberWindowPos = false;

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -36,7 +36,7 @@ public:
 	bool bRemove16by10BlackBars = true;
 	bool bFixDPIScale = true;
 	bool bFixDisplayMode = true;
-	int iCustomRefreshRate = -1;
+	bool bOnlyShowHighestRefreshRates = false;
 	bool bOverrideLaserColor = false;
 	bool bRainbowLaser = false;
 	int iLaserR = 255;

--- a/dllmain/WndProcHook.cpp
+++ b/dllmain/WndProcHook.cpp
@@ -6,13 +6,12 @@
 #include "ConsoleWnd.h"
 #include <iniReader.h>
 
-WNDPROC oWndProc;
 HWND hWindow;
-
-static uint32_t* ptrMouseDeltaX;
 
 bool bIsMoving;
 
+int curSizeX;
+int curSizeY;
 int curPosX;
 int curPosY;
 
@@ -89,8 +88,8 @@ void DisableClipCursor(bool bCenterCursor)
 	#endif
 }
 
-// Our new hooked WndProc function
-LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT(CALLBACK* GameWndProc)(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK WndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	switch (uMsg) {
 		case WM_KEYDOWN:
@@ -108,6 +107,12 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			curPosY = (int)(short)HIWORD(lParam);   // vertical position 
 			break;
 
+		case WM_SIZE:
+			// Get current window position
+			curSizeX = (int)LOWORD(lParam);   // horizontal size 
+			curSizeY = (int)HIWORD(lParam);   // vertical size 
+			break;
+
 		case WM_ENTERSIZEMOVE:
 			bIsMoving = true;
 			break;
@@ -117,9 +122,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 			EnableClipCursor(hWindow);
 
+			// Write new window position
 			if (re4t::cfg->bRememberWindowPos)
 			{
-				// Write new window position
 				#ifdef VERBOSE
 				con.log("curPosX = %d", curPosY);
 				con.log("curPosY = %d", curPosX);
@@ -133,6 +138,15 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				ini.setInt("DISPLAY", "WindowPositionX", curPosX);
 				ini.setInt("DISPLAY", "WindowPositionY", curPosY);
 			}
+
+			// Resize game's resolution
+			if (curSizeX != *bio4::g_D3D::Width_1 ||
+				curSizeY != *bio4::g_D3D::Height_1)
+			{
+				bio4::D3D_SetupResolution(curSizeX, curSizeY);
+				bio4::ScreenReSize(0x200, 0x1C0);
+			}
+
 			break;
 
 		case WM_ACTIVATEAPP:
@@ -150,7 +164,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 		case WM_KILLFOCUS:
 			// Clear the mouse delta value if we lose focus
-			*(int32_t*)(ptrMouseDeltaX) = 0;
 			pInput->clear_raw_mouse_delta();
 
 			// Unlock cursor
@@ -166,11 +179,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	if (bCfgMenuOpen)
 	{
 		// Clear the mouse delta value if the cfg menu is open
-		*(int32_t*)(ptrMouseDeltaX) = 0;
 		pInput->clear_raw_mouse_delta();
 	}
 
-	return CallWindowProc(oWndProc, hWnd, uMsg, wParam, lParam);
+	return GameWndProc(hWnd, uMsg, wParam, lParam);
 }
 
 // CreateWindowExA hook to get the hWindow and set up the WndProc hook
@@ -179,28 +191,77 @@ HWND __stdcall CreateWindowExA_Hook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR 
 	// Perform LAA check/prompt before game window has a chance to be created
 	LAACheck();
 
-	int windowX = re4t::cfg->iWindowPositionX < 0 ? CW_USEDEFAULT : re4t::cfg->iWindowPositionX;
-	int windowY = re4t::cfg->iWindowPositionY < 0 ? CW_USEDEFAULT : re4t::cfg->iWindowPositionY;
-
-	hWindow = CreateWindowExA(dwExStyle, lpClassName, lpWindowName, re4t::cfg->bWindowBorderless ? WS_POPUP : dwStyle, windowX, windowY, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-
+	hWindow = CreateWindowExA(dwExStyle, lpClassName, lpWindowName, 0, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+	
+	// Register hWnd for input processing
 	spd::log()->info("{} -> Window created; Registering for input", __FUNCTION__);
 
-	// Register hWnd for input processing
 	pInput = re4t::input::register_window(hWindow);
-
-	oWndProc = (WNDPROC)SetWindowLongPtr(hWindow, GWL_WNDPROC, (LONG_PTR)WndProc);
 
 	return hWindow;
 }
 
+BOOL __stdcall AdjustWindowRectEx_Hook(LPRECT lpRect, DWORD dwStyle, BOOL bMenu, DWORD dwExStyle)
+{
+	DWORD lStyle = GetWindowLong(hWindow, GWL_STYLE);
+	DWORD lExStyle = GetWindowLong(hWindow, GWL_EXSTYLE);
+
+	bool isFullscreen = *bio4::g_D3D::Fullscreen;
+
+	if (re4t::cfg->bWindowBorderless && !isFullscreen)
+	{
+		lStyle &= ~(WS_CAPTION | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU);
+		lStyle |= (WS_POPUP);
+	}
+	else
+	{
+		lStyle |= (WS_MINIMIZEBOX | WS_SYSMENU);
+		if (re4t::cfg->bEnableWindowResize && !isFullscreen)
+			lStyle |= (WS_MAXIMIZEBOX | WS_THICKFRAME);
+	}
+
+	SetWindowLong(hWindow, GWL_STYLE, lStyle);
+
+	return AdjustWindowRectEx(lpRect, lStyle, bMenu, lExStyle);
+}
+
+BOOL __stdcall MoveWindow_Hook(HWND hWnd, int X, int Y, int nWidth, int nHeight, BOOL bRepaint)
+{
+	bool isFullscreen = *bio4::g_D3D::Fullscreen;
+
+	int WindowX = X;
+	int WindowY = Y;
+
+	if (re4t::cfg->iWindowPositionX != -1 && !isFullscreen)
+		WindowX = re4t::cfg->iWindowPositionX;
+
+	if (re4t::cfg->iWindowPositionX != -1 && !isFullscreen)
+		WindowX = re4t::cfg->iWindowPositionX;
+
+	return MoveWindow(hWnd, WindowX, WindowY, nWidth, nHeight, bRepaint);
+}
+
 void re4t::init::WndProcHook()
 {
-	auto pattern = hook::pattern("DB 05 ? ? ? ? D9 45 ? D9 C0 DE CA D9 C5");
-	ptrMouseDeltaX = *pattern.count(1).get(0).get<uint32_t*>(2);
-
 	// CreateWindowEx hook
-	pattern = hook::pattern("68 00 00 00 80 56 68 ? ? ? ? 68 ? ? ? ? 6A 00");
+	auto pattern = hook::pattern("68 00 00 00 80 56 68 ? ? ? ? 68 ? ? ? ? 6A 00");
 	injector::MakeNOP(pattern.get_first(0x12), 6);
 	injector::MakeCALL(pattern.get_first(0x12), CreateWindowExA_Hook, true);
+
+	// WndProc hook
+	pattern = hook::pattern("C7 45 ? ? ? ? ? 89 75 ? 89 75 ? 89 45 ? FF 15 ? ? ? ? 6A");
+	uint32_t* wndproc_addr = pattern.count(1).get(0).get<uint32_t>(3);
+	uint32_t GameWndProcAddr = *(uint32_t*)wndproc_addr;
+	GameWndProc = (LRESULT(WINAPI*)(HWND, UINT, WPARAM, LPARAM))GameWndProcAddr;
+	injector::WriteMemory<uint32_t>(wndproc_addr, (uint32_t)&WndProc_hook, true);
+
+	// Hook AdjustWindowRectEx call inside sub_93A0B0 to apply our style changes
+	pattern = hook::pattern("FF 15 ? ? ? ? 8B 4D ? 2B 4D ? 8B 55");
+	injector::MakeNOP(pattern.get_first(0), 6);
+	InjectHook(pattern.get_first(0), AdjustWindowRectEx_Hook, PATCH_CALL);
+
+	// Hook MoveWindow call inside sub_93A0B0 to apply our custom X Y window position
+	pattern = hook::pattern("FF 15 ? ? ? ? 8B 0D ? ? ? ? 6A 01");
+	injector::MakeNOP(pattern.get_first(0), 6);
+	InjectHook(pattern.get_first(0), MoveWindow_Hook, PATCH_CALL);
 }

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -469,14 +469,19 @@ void cfgMenuRender()
 					{
 						ImGui_ColumnSwitch();
 
-						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("DisableVsync", &re4t::cfg->bDisableVsync);
+						if (ImGui::Checkbox("DisableVsync", &re4t::cfg->bDisableVsync))
+						{
+							re4t::cfg->HasUnsavedChanges = true;
+
+							// Trigger resolution change to make apply the new v-sync option
+							bio4::D3D_SetupResolution(*bio4::g_D3D::Width_1, *bio4::g_D3D::Height_1);
+							bio4::ScreenReSize(0x200, 0x1C0);
+						}
 
 						ImGui_ItemSeparator();
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 						ImGui::TextWrapped("Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.");
-
-						ImGui::Bullet(); ImGui::SameLine(); ImGui::TextWrapped("Change the game's resolution or restart the game for this option to take effect.");
 					}
 
 					// Aspect ratio tweaks
@@ -726,13 +731,37 @@ void cfgMenuRender()
 						if (ImGui::Checkbox("WindowBorderless", &re4t::cfg->bWindowBorderless))
 						{
 							re4t::cfg->HasUnsavedChanges = true;
-							NeedsToRestart = true;
+
+							// Trigger resolution change to apply changes
+							if (!*bio4::g_D3D::Fullscreen)
+							{
+								bio4::D3D_SetupResolution(*bio4::g_D3D::Width_1, *bio4::g_D3D::Height_1);
+								bio4::ScreenReSize(0x200, 0x1C0);
+							}
 						}
 
 						ImGui_ItemSeparator();
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 						ImGui::TextWrapped("Whether to use a borderless-window when using windowed-mode.");
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui_ItemSeparator2();
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+
+						if (ImGui::Checkbox("EnableWindowResize", &re4t::cfg->bEnableWindowResize))
+						{
+							re4t::cfg->HasUnsavedChanges = true;
+
+							// Trigger resolution change to apply changes
+							if (!*bio4::g_D3D::Fullscreen)
+							{
+								bio4::D3D_SetupResolution(*bio4::g_D3D::Width_1, *bio4::g_D3D::Height_1);
+								bio4::ScreenReSize(0x200, 0x1C0);
+							}
+						}
+
+						ImGui::TextWrapped("When playing in windowed mode, allow the game window to be resized by dragging the window borders.");
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 						ImGui_ItemSeparator2();

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -469,16 +469,14 @@ void cfgMenuRender()
 					{
 						ImGui_ColumnSwitch();
 
-						if (ImGui::Checkbox("DisableVsync", &re4t::cfg->bDisableVsync))
-						{
-							re4t::cfg->HasUnsavedChanges = true;
-							NeedsToRestart = true;
-						}
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("DisableVsync", &re4t::cfg->bDisableVsync);
 
 						ImGui_ItemSeparator();
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 						ImGui::TextWrapped("Force V-Sync to be disabled. For some reason the vanilla game doesn't provide a functional way to do this.");
+
+						ImGui::Bullet(); ImGui::SameLine(); ImGui::TextWrapped("Change the game's resolution or restart the game for this option to take effect.");
 					}
 
 					// Aspect ratio tweaks
@@ -557,29 +555,15 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Allows game to use non - 60Hz refresh rates in fullscreen, fixing the black screen issue people have when starting the game.");
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
-						ImGui_ItemSeparator2();
-						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 
-						ImGui::Text("CustomRefreshRate");
-						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
-
-						ImGui::PushItemWidth(100 * re4t::cfg->fFontSizeScale * esHook._cur_monitor_dpi);
 						ImGui::BeginDisabled(!re4t::cfg->bFixDisplayMode);
-						ImGui::InputInt("Hz", &re4t::cfg->iCustomRefreshRate);
-						ImGui::EndDisabled();
-						ImGui::PopItemWidth();
-
-						if (ImGui::IsItemEdited())
+						if (ImGui::Checkbox("OnlyShowHighestRefreshRates", &re4t::cfg->bOnlyShowHighestRefreshRates))
 						{
 							re4t::cfg->HasUnsavedChanges = true;
 							NeedsToRestart = true;
 						}
-
-						ImGui::Spacing();
-
-						ImGui::TextWrapped("Determines a custom refresh rate for the game to use.");
-						ImGui::TextWrapped("Requires FixDisplayMode to be enabled.");
-						ImGui::TextWrapped("-1 will make it try to use the current refresh rate as reported by Windows.");
+						ImGui::TextWrapped("When using FixDisplayMode, only display the highest refresh rate available for each resolution in the game's config menu.");
+						ImGui::EndDisabled();
 					}
 
 					// OverrideLaserColor

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -779,7 +779,19 @@ void cfgMenuRender()
 						ImGui::EndDisabled();
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
-						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("RememberWindowPos", &re4t::cfg->bRememberWindowPos);
+						if (ImGui::Checkbox("RememberWindowPos", &re4t::cfg->bRememberWindowPos))
+						{
+							re4t::cfg->HasUnsavedChanges = true;
+
+							if (re4t::cfg->bRememberWindowPos)
+							{
+								RECT rect;
+								GetWindowRect(hWindow, &rect);
+
+								re4t::cfg->iWindowPositionX = rect.left;
+								re4t::cfg->iWindowPositionY = rect.top;
+							}
+						}
 						ImGui::TextWrapped("Remember the last window position. This automatically updates the \"X Pos\" and \"Y Pos\" values above.");
 					}
 

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -665,6 +665,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
       <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <ClCompile Include="..\wrappers\wrappers.cpp" />
+    <ClCompile Include="DisplayModeFix.cpp" />
     <ClCompile Include="FrameRateFixes.cpp" />
     <ClCompile Include="AudioTweaks.cpp" />
     <ClCompile Include="AutoUpdater.cpp" />

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -574,6 +574,9 @@
     <ClCompile Include="Trainer_ItemMgr.cpp">
       <Filter>dllmain</Filter>
     </ClCompile>
+    <ClCompile Include="DisplayModeFix.cpp">
+      <Filter>dllmain</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\external\injector\include\injector\assembly.hpp">

--- a/dxvk/src/d3d9/d3d9_adapter.cpp
+++ b/dxvk/src/d3d9/d3d9_adapter.cpp
@@ -10,6 +10,7 @@
 #include "../util/util_ratio.h"
 
 #include <cfloat>
+#include <log.h>
 
 namespace dxvk {
 
@@ -811,6 +812,19 @@ namespace dxvk {
         
         return a.RefreshRate < b.RefreshRate;
     });
+
+    // Log display modes for troubleshooting
+    if (re4t::cfg->bVerboseLog)
+    {
+        spd::log()->info("+------------+------------+");
+        spd::log()->info("| D3D9Adapter::CacheModes |");
+        spd::log()->info("+------------+------------+");
+        for (std::vector<D3DDISPLAYMODEEX>::iterator it = m_modes.begin(); it != m_modes.end(); ++it) {
+            D3DDISPLAYMODEEX mode = *it;
+            spd::log()->info("| {:<5}x {:<5} {:>7} Hz |", mode.Width, mode.Height, mode.RefreshRate);
+        }
+        spd::log()->info("+------------+------------+");
+    }
   }
 
 }

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -47,10 +47,8 @@ FixDPIScale = true
 ; when starting it.
 FixDisplayMode = true
 
-; Determines a custom refresh rate for the game to use.
-; Requires FixDisplayMode to be enabled.
-; -1 will make it try to use the current refresh rate as reported by Windows.
-CustomRefreshRate = -1
+; When using FixDisplayMode, only display the highest refresh rate available for each resolution in the game's config menu.
+OnlyShowHighestRefreshRates = false
 
 ; Overrides the color of the laser sights.
 ; Values used here are RGB, in that order.

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -93,6 +93,9 @@ EnableGCScopeBlur = true
 ; Whether to use a borderless-window when using windowed-mode.
 WindowBorderless = false
 
+; When playing in windowed mode, allow the game window to be resized by dragging the window borders.
+EnableWindowResize = false
+
 ; Position to draw the game window when using windowed mode.
 ; -1 will use the games default (usually places it at 0,0)
 WindowPositionX = -1


### PR DESCRIPTION
This should improve the situation in #411.
``FixDisplayMode`` currently works fine, but I was thinking we could still improve it a bit, so this is what I came up with:

- Get rid of the ``CustomRefreshRate`` int. Read the refresh rate from the game's ``config.ini`` instead.
- Provide the option to choose the refresh rate using the game's config menu. To do this, we replace ``D3D_FillDisplayModeVector`` with our own function to make the vector of resolutions. This lets us have a finer control of the list, allowing us to have duplicated resolutions with different refresh rates:
![image](https://user-images.githubusercontent.com/33870163/210075861-58208b83-21e6-4792-92ad-2cd1a8160837.png)
![image](https://user-images.githubusercontent.com/33870163/210075958-9f988554-cb5c-454c-abfe-48a9e638a653.png)
- Hook ``D3D_GetDisplayModeForWidthHeight`` to make it get the display mode with the refresh rate we want, instead of only being able to get 60 Hz refresh rates.
- At startup, validate the display mode in the game's ``config.ini``. Use it if the primary display supports it, otherwise fall back to using the desktop's resolution and refresh rate. (This is and the original ``D3D_GetDisplayModeForWidthHeight`` behavior are what would cause the "black screen" bug originally).
- Hook ``ConfigWriteINI`` to make sure the current resolution is being saved correctly.

An option is also provided to show only the highest refresh rate for each resolution.

This should make the game work with any refresh rate, above or below 60 Hz.

Should probably test it a bit more before merging. But there's one issue: I can't test if this 100% still fixes the original black screen issue, since I was never able to reproduce that in the first place. All my displays have 60 Hz modes. @emoose, maybe we should ping someone here who has the issue? I don't know anyone, though...

Edit: Also decided to update our window hooks a bit. Borderless Window mode can now be toggled at run time, added an option to resize the game window by dragging the window borders, and made the v-sync toggle also work at runtime.
We're also now hooking ``WndProc`` using a slightly better method (in theory...).

TODO: Move the ``GX_DisplayMode`` struct somewhere in the SDK?