### PR TITLE
Improved LimitMatildaBurst

### DIFF
--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -108,7 +108,8 @@ namespace bio4 {
 
 	void(__cdecl* QuakeExec)(uint32_t No, uint32_t Delay, int Time, float Scale, uint32_t Axis);
   
-	bool(__cdecl* joyFireOn)();
+	BOOL(__cdecl* joyFireTrg)();
+	BOOL(__cdecl* joyFireOn)();
 };
 
 // Current play time (H, M, S)
@@ -1055,6 +1056,10 @@ bool re4t::init::Game()
 	// PlChangeData funcptr
 	pattern = hook::pattern("75 ? E8 ? ? ? ? E8 ? ? ? ? 38 1D ? ? ? ?");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0x7)).as_int(), bio4::PlChangeData);
+
+	// joyFireTrg ptr
+	pattern = hook::pattern("E8 ? ? ? ? 85 C0 74 ? 8B 96 D8 07 00 00 8B 4A 34 F6 81 55 03");
+	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint8_t>(0)).as_int(), bio4::joyFireTrg);
 
 	// joyFireOn ptr
 	pattern = hook::pattern("E8 ? ? ? ? 85 C0 74 ? 8B 8E D8 07 00 00 8B 49 34 E8 ? ? ? ? 84 C0 0F ? ? ? ? ? 8B");

--- a/dllmain/SDK/pad.h
+++ b/dllmain/SDK/pad.h
@@ -171,5 +171,6 @@ namespace bio4
 {
 	extern bool(__cdecl* KeyOnCheck_0)(KEY_BTN a1);
 	extern void(__cdecl* KeyStop)(uint64_t un_stop_bit);
-	extern bool(__cdecl* joyFireOn)();
+	extern BOOL(__cdecl* joyFireTrg)();
+	extern BOOL(__cdecl* joyFireOn)();
 }

--- a/dllmain/SDK/player.h
+++ b/dllmain/SDK/player.h
@@ -30,7 +30,7 @@ public:
 	int32_t m_Work1_42C;
 	int32_t m_Work2_430;
 	int32_t m_Work3_434;
-	int32_t plunk_438;
+	int32_t m_Work4_438;
 	float m_Work5_43C;
 	int32_t m_Work6_440;
 	int32_t m_Work7_444;


### PR DESCRIPTION
Small problem with the old Matilda burst limit code was that if you pressed fire too early after a reload, nothing would happen. This fixes that.