### PR TITLE
Misc: fix some item descriptions in the merchant and examine subscreens

### DIFF
--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -1070,7 +1070,7 @@ bool re4t::init::Game()
 	pattern = hook::pattern("E8 ? ? ? ? B9 ? ? ? ? 83 C4 ? 66 3B ? 0F 84");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), WeaponId2ChargeNum);
 
-	// cItem__specialTuned funcptr
+	// cItem::specialTuned funcptr
 	pattern = hook::pattern("8B CE E8 ? ? ? ? 84 C0 74 ? C6");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(2)).as_int(), cItem__specialTuned);
 

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -32,6 +32,7 @@ cItemMgr__get_Fn cItemMgr__get = nullptr;
 cItemMgr__erase_Fn cItemMgr__erase = nullptr;
 cItemMgr__num_0_Fn cItemMgr__num_0 = nullptr;
 cItemMgr__bulletNumTotal_Fn cItemMgr__bulletNumTotal = nullptr;
+cItem__specialTuned_Fn cItem__specialTuned = nullptr;
 WeaponId2ChargeNum_Fn WeaponId2ChargeNum = nullptr;
 
 // event.h externs
@@ -1068,6 +1069,10 @@ bool re4t::init::Game()
 	// WeaponId2ChargeNum funcptr
 	pattern = hook::pattern("E8 ? ? ? ? B9 ? ? ? ? 83 C4 ? 66 3B ? 0F 84");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0)).as_int(), WeaponId2ChargeNum);
+
+	// cItem__specialTuned funcptr
+	pattern = hook::pattern("8B CE E8 ? ? ? ? 84 C0 74 ? C6");
+	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(2)).as_int(), cItem__specialTuned);
 
 	// levelDataAdd funcptr
 	pattern = hook::pattern("E8 ? ? ? ? A1 ? ? ? ? 83 C4 ? 81 88 ? ? ? ? ? ? ? ? 8B 0D ? ? ? ? 0F B7 81 ? ? ? ? 8D 88");

--- a/dllmain/Game.h
+++ b/dllmain/Game.h
@@ -12,6 +12,7 @@
 #include "SDK/global.h"
 #include "SDK/snd.h"
 #include "SDK/ID.h"
+#include "SDK/message.h"
 #include "SDK/title.h"
 #include "SDK/light.h"
 #include "SDK/item.h"

--- a/dllmain/Gameplay.cpp
+++ b/dllmain/Gameplay.cpp
@@ -247,7 +247,7 @@ void re4t::init::Gameplay()
 		injector::WriteMemory(pattern.count(1).get(0).get<uint32_t>(6), &newArray, true);
 		*/
 
-		spd::log()->info("BlancedChicagoTypewriter enabled");
+		spd::log()->info("BalancedChicagoTypewriter enabled");
 	}
 
 	// Unlock JP-only classic camera angle during Ashley segment

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -529,7 +529,7 @@ uint16_t* GetEtcFlgPtr_Hook(uint32_t etc_no, uint16_t room_no)
 }
 
 void (__cdecl* itemCaption)(ITEM_ID a1);
-void __cdecl itemCaption_hook(ITEM_ID a1)
+void __cdecl BuyMenuSelect__move_itemCaption_hook(ITEM_ID a1)
 {
 	if (a1 == (ITEM_ID)EItemId::Thompson && re4t::cfg->bBalancedChicagoTypewriter)
 		a1 = (ITEM_ID)EItemId::Ada_Machine_Gun;
@@ -537,14 +537,14 @@ void __cdecl itemCaption_hook(ITEM_ID a1)
 	itemCaption(a1);
 }
 
-cItem SsItemExamine__move__cItem;
+cItem SsItemExamine__move_cItem;
 bool(__fastcall* MesSet)(MessageControl* thisptr, void* unused, uint32_t num, int px, int py, uint32_t attr, int wk, uint8_t col, int font_no);
 bool __fastcall SsItemExamine__move_MesSet_hook(MessageControl* thisptr, void* unused, uint32_t num, int px, int py, uint32_t attr, int wk, uint8_t col, int font_no)
 {
-	if (num == (ITEM_ID)EItemId::Thompson && !SsItemExamine__move__cItem.specialTuned() && re4t::cfg->bBalancedChicagoTypewriter)
+	if (num == (ITEM_ID)EItemId::Thompson && !SsItemExamine__move_cItem.specialTuned() && re4t::cfg->bBalancedChicagoTypewriter)
 		num = (ITEM_ID)EItemId::Ada_Machine_Gun;
 
-	if (num == (ITEM_ID)EItemId::Ruger_SA && !SsItemExamine__move__cItem.specialTuned() && re4t::cfg->bFixSilencedHandgunDescription)
+	if (num == (ITEM_ID)EItemId::Ruger_SA && !SsItemExamine__move_cItem.specialTuned() && re4t::cfg->bFixSilencedHandgunDescription)
 		num = (ITEM_ID)EItemId::Ruger;
 
 	return MesSet(thisptr, nullptr, num, px, py, attr, wk, col, font_no);
@@ -1298,7 +1298,7 @@ void re4t::init::Misc()
 	// Silenced Handgun: display "A standard 9mm handgun" when it has less than max firepower
 	// Leon's Chicago Typewriter: display "This machinegun is outfitted with a powerful .45 caliber magazine" when it has less than max capacity
 	{
-		// SellMenuSelect__move
+		// SellMenuSelect::move
 		auto pattern = hook::pattern("8B F0 E8 ? ? ? ? 0F b7 D0 52");
 		struct GetMsgID_hook
 		{
@@ -1339,23 +1339,23 @@ void re4t::init::Misc()
 			}
 		}; injector::MakeInline<GetMsgID_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
 
-		// LvUpMenuSelect__move
+		// LvUpMenuSelect::move
 		pattern = hook::pattern("8B F0 E8 ? ? ? ? 8B ? ? 0F B7 C0");
 		injector::MakeInline<GetMsgID_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
 
-		// BuyMenuSelect__move
+		// BuyMenuSelect::move
 		pattern = hook::pattern("0F B7 10 52 E8 ? ? ? ? 83");
 		ReadCall(pattern.count(1).get(0).get<uint8_t>(4), itemCaption);
-		InjectHook(pattern.count(1).get(0).get<uint32_t>(4), itemCaption_hook);
+		InjectHook(pattern.count(1).get(0).get<uint32_t>(4), BuyMenuSelect__move_itemCaption_hook);
 
-		// SsItemExamine__move
+		// SsItemExamine::move
 		pattern = hook::pattern("0F B7 46 06 8B D0 C1");
 		struct SsItemExamine__move_SavecItem
 		{
 			void operator()(injector::reg_pack& regs)
 			{
 				// capture cItem so we can check its upgrade status
-				SsItemExamine__move__cItem = *(cItem*)regs.esi;
+				SsItemExamine__move_cItem = *(cItem*)regs.esi;
 
 				// code we overwrote
 				regs.eax = *(uint32_t*)(regs.esi + 0x6);

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1330,7 +1330,7 @@ void re4t::init::Misc()
 						item.id_0 = 260;
 					break;
 				case EItemId::Thompson:
-					if (!item.specialTuned() && re4t::cfg->bFixSilencedHandgunDescription)
+					if (!item.specialTuned() && re4t::cfg->bBalancedChicagoTypewriter)
 						item.id_0 = (ITEM_ID)EItemId::Ada_Machine_Gun;
 					break;
 				}

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -528,6 +528,28 @@ uint16_t* GetEtcFlgPtr_Hook(uint32_t etc_no, uint16_t room_no)
 	return ret;
 }
 
+void (__cdecl* itemCaption)(ITEM_ID a1);
+void __cdecl itemCaption_hook(ITEM_ID a1)
+{
+	if (a1 == (ITEM_ID)EItemId::Thompson && re4t::cfg->bBalancedChicagoTypewriter)
+		a1 = (ITEM_ID)EItemId::Ada_Machine_Gun;
+
+	itemCaption(a1);
+}
+
+cItem SsItemExamine__move__cItem;
+bool(__fastcall* MesSet)(MessageControl* thisptr, void* unused, uint32_t num, int px, int py, uint32_t attr, int wk, uint8_t col, int font_no);
+bool __fastcall SsItemExamine__move_MesSet_hook(MessageControl* thisptr, void* unused, uint32_t num, int px, int py, uint32_t attr, int wk, uint8_t col, int font_no)
+{
+	if (num == (ITEM_ID)EItemId::Thompson && !SsItemExamine__move__cItem.specialTuned())
+		num = (ITEM_ID)EItemId::Ada_Machine_Gun;
+
+	if (num == (ITEM_ID)EItemId::Ruger_SA && !SsItemExamine__move__cItem.specialTuned())
+		num = (ITEM_ID)EItemId::Ruger;
+
+	return MesSet(thisptr, nullptr, num, px, py, attr, wk, col, font_no);
+}
+
 void re4t::init::Misc()
 {
 	// Hooks to allow reloading without aiming
@@ -1270,6 +1292,79 @@ void re4t::init::Misc()
 		*g_item_price_tbl_num += 1;
 
 		spd::log()->info("AllowSellingHandgunSilencer enabled");
+	}
+
+	// Fix some item descriptions in the merchant and examine subscreens
+	// Silenced Handgun: display "A standard 9mm handgun" when it has less than max firepower
+	// Leon's Chicago Typewriter: display "This machinegun is outfitted with a powerful .45 caliber magazine" when it has less than max capacity
+	{
+		// SellMenuSelect__move
+		auto pattern = hook::pattern("8B F0 E8 ? ? ? ? 0F b7 D0 52");
+		struct GetMsgID_hook
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				cItem item = *(cItem*)regs.eax;
+
+				// reimplimentation of getMsgID
+				switch ((EItemId)item.id_0)
+				{
+				case EItemId::FN57:
+					if (item.specialTuned())
+						item.id_0 = 256;
+					break;
+				case EItemId::Ruger:
+					if (item.specialTuned())
+						item.id_0 = 257;
+					break;
+				case EItemId::Shotgun:
+					if (item.specialTuned())
+						item.id_0 = 258;
+					break;
+				case EItemId::Mine:
+					if (item.specialTuned())
+						item.id_0 = 259;
+					break;
+				case EItemId::SW500:
+					if (item.specialTuned())
+						item.id_0 = 260;
+					break;
+				case EItemId::Thompson:
+					if (!item.specialTuned())
+						item.id_0 = (ITEM_ID)EItemId::Ada_Machine_Gun;
+					break;
+				}
+
+				regs.eax = item.id_0;
+			}
+		}; injector::MakeInline<GetMsgID_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
+
+		// LvUpMenuSelect__move
+		pattern = hook::pattern("8B F0 E8 ? ? ? ? 8B ? ? 0F B7 C0");
+		injector::MakeInline<GetMsgID_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(7));
+
+		// BuyMenuSelect__move
+		pattern = hook::pattern("0F B7 10 52 E8 ? ? ? ? 83");
+		ReadCall(pattern.count(1).get(0).get<uint8_t>(4), itemCaption);
+		InjectHook(pattern.count(1).get(0).get<uint32_t>(4), itemCaption_hook);
+
+		// SsItemExamine__move
+		pattern = hook::pattern("0F B7 46 06 8B D0 C1");
+		struct SsItemExamine__move_SavecItem
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				// capture cItem so we can check its upgrade status
+				SsItemExamine__move__cItem = *(cItem*)regs.esi;
+
+				// code we overwrote
+				regs.eax = *(uint32_t*)(regs.esi + 0x6);
+				regs.edx = regs.eax;
+			}
+		}; injector::MakeInline<SsItemExamine__move_SavecItem>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
+		pattern = hook::pattern("68 84 00 02 00 51 53");
+		ReadCall(pattern.count(1).get(0).get<uint8_t>(13), MesSet);
+		InjectHook(pattern.count(1).get(0).get<uint32_t>(13), SsItemExamine__move_MesSet_hook, PATCH_CALL);
 	}
 
 	// Allow physics to apply to tactical vest outfit

--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -541,10 +541,10 @@ cItem SsItemExamine__move__cItem;
 bool(__fastcall* MesSet)(MessageControl* thisptr, void* unused, uint32_t num, int px, int py, uint32_t attr, int wk, uint8_t col, int font_no);
 bool __fastcall SsItemExamine__move_MesSet_hook(MessageControl* thisptr, void* unused, uint32_t num, int px, int py, uint32_t attr, int wk, uint8_t col, int font_no)
 {
-	if (num == (ITEM_ID)EItemId::Thompson && !SsItemExamine__move__cItem.specialTuned())
+	if (num == (ITEM_ID)EItemId::Thompson && !SsItemExamine__move__cItem.specialTuned() && re4t::cfg->bBalancedChicagoTypewriter)
 		num = (ITEM_ID)EItemId::Ada_Machine_Gun;
 
-	if (num == (ITEM_ID)EItemId::Ruger_SA && !SsItemExamine__move__cItem.specialTuned())
+	if (num == (ITEM_ID)EItemId::Ruger_SA && !SsItemExamine__move__cItem.specialTuned() && re4t::cfg->bFixSilencedHandgunDescription)
 		num = (ITEM_ID)EItemId::Ruger;
 
 	return MesSet(thisptr, nullptr, num, px, py, attr, wk, col, font_no);
@@ -1330,7 +1330,7 @@ void re4t::init::Misc()
 						item.id_0 = 260;
 					break;
 				case EItemId::Thompson:
-					if (!item.specialTuned())
+					if (!item.specialTuned() && re4t::cfg->bFixSilencedHandgunDescription)
 						item.id_0 = (ITEM_ID)EItemId::Ada_Machine_Gun;
 					break;
 				}

--- a/dllmain/SDK/item.h
+++ b/dllmain/SDK/item.h
@@ -290,8 +290,11 @@ struct upgradeTypes {
 
 extern std::unordered_map<EItemId, upgradeTypes> extra_upgrades;
 
+class cItem;
 typedef uint16_t(__cdecl* WeaponId2ChargeNum_Fn)(ITEM_ID item_id, int level);
+typedef bool(__thiscall* cItem__specialTuned_Fn)(cItem* thisptr);
 extern WeaponId2ChargeNum_Fn WeaponId2ChargeNum;
+extern cItem__specialTuned_Fn cItem__specialTuned;
 
 class cItem
 {
@@ -364,6 +367,11 @@ public:
 	inline void setAmmo(int newVal)
 	{
 		weapon_6[1] = newVal << 3;
+	}
+	
+	inline bool specialTuned()
+	{
+		return cItem__specialTuned(this);
 	}
 };
 assert_size(cItem, 0xE);

--- a/dllmain/SDK/item.h
+++ b/dllmain/SDK/item.h
@@ -369,6 +369,7 @@ public:
 		weapon_6[1] = newVal << 3;
 	}
 	
+	// determines whether a weapon has its exclusive upgrade
 	inline bool specialTuned()
 	{
 		return cItem__specialTuned(this);

--- a/dllmain/SDK/message.h
+++ b/dllmain/SDK/message.h
@@ -1,0 +1,110 @@
+#pragma once
+#include "basic_types.h"
+
+struct MSG_QUE
+{
+	int16_t pos_X_0;
+	int16_t pos_Y_2;
+	uint16_t glyphId_4;
+	uint8_t width_6;
+	uint8_t height_7;
+	uint32_t color_8;
+	struct MessageFont* m_p_font_C;
+};
+assert_size(MSG_QUE, 0x10);
+
+struct Message
+{
+	void* __vftable;
+	uint32_t backup_Flags_STOP_4;
+	uint32_t be_flag_8;
+	uint8_t r_no_0_C;
+	uint8_t r_no_1_D;
+	uint8_t r_no_2_E;
+	uint8_t r_no_3_F;
+	uint32_t m_state_10;
+	float m_scale_w_14;
+	float m_scale_h_18;
+	int8_t m_font_w_1C;
+	int8_t m_font_h_1D;
+	uint16_t m_item_no_1E;
+	uint16_t m_ot_type_20;
+	uint16_t m_ot_no_22;
+	struct MessageFont* m_pFont_24;
+	int16_t m_screenPos_X_28;
+	int16_t m_screenPos_Y_2A;
+	int16_t m_pos0_x_2C[16];
+	int16_t m_pos0_y_4C;
+	int16_t m_width_4E[16];
+	int16_t m_width_max_6E;
+	int16_t m_height_70;
+	int16_t m_bttn_wait_72;
+	int8_t m_btn_74;
+	int8_t m_evt_no_75;
+	int8_t m_lines_76;
+	uint8_t unk_77[1];
+	int16_t m_number_width_78;
+	int16_t m_line_gap_7A;
+	int16_t m_char_gap_7C;
+	WORD word7E;
+	uint32_t m_col_80;
+	uint32_t m_attr_84;
+	int16_t m_spd_88;
+	int16_t m_spd_cnt_8A;
+	float float8C;
+	int16_t m_spd_old_90;
+	int16_t m_spd_flag_92;
+	int16_t padpadpad_94;
+	int16_t m_wait_cnt_96;
+	uint16_t m_jump_mes_98[3];
+	int8_t m_jump_idx_9E;
+	int8_t m_jump_max_9F;
+	uint16_t* m_pMes_A0;
+	uint16_t* m_pRetAddr_A4;
+	struct Message::MessageFont* m_pRetFont_A8;
+	uint32_t m_number_AC[2];
+	uint32_t m_div_B4[2];
+	uint32_t m_number_bak_BC[2];
+	uint32_t m_div_bak_C4[2];
+	uint16_t m_se_blk_CC;
+	uint16_t m_se_no_CE;
+	MSG_QUE* m_queue_D0;
+	MSG_QUE* m_pMque_D4;
+	MSG_QUE* m_selTbl_D8[8];
+	char m_selTbl_size_F8;
+	char m_sel_F9;
+	char m_cur_FA;
+	char m_cursol_time_FB;
+	char m_who_FC;
+	char m_turn_FD;
+	BYTE field_FE;
+	BYTE field_FF;
+};
+assert_size(Message, 0x100);
+
+struct	GXTlutObj { uint32_t dummy_0[3]; };
+assert_size(GXTlutObj, 0xC);
+
+struct FONT_TEX
+{
+	GXTexObj texobj_0;
+	GXTlutObj tlutobj_20;
+	float mat[2][4];
+	uint8_t unk_4C[16];
+	uint32_t field_5C;
+	void* data_60;
+};
+assert_size(FONT_TEX, 0x64);
+
+struct MessageControl
+{
+	void* __vftable;
+	int8_t m_sel_sav_4;
+	struct Message m_Msg_8[16];
+	uint8_t* m_font_addr_1008[4];
+	uint32_t m_state_1018;
+	FONT_TEX m_mTex[4][2];
+	float m_stop_133C;
+};
+assert_size(MessageControl, 0x1340);
+

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -828,7 +828,7 @@ void WriteSettings(std::wstring iniPath, bool trainerIni)
 	iniReader.WriteBoolean("GAMEPLAY", "AllowAshleySuplex", re4t::cfg->bAllowAshleySuplex);
 	iniReader.WriteBoolean("GAMEPLAY", "FixDitmanGlitch", re4t::cfg->bFixDitmanGlitch);
 	iniReader.WriteBoolean("GAMEPLAY", "AllowSellingHandgunSilencer", re4t::cfg->bAllowSellingHandgunSilencer);
-	iniReader.WriteBoolean("GAMEPLAY", "BlancedChicagoTypewriter", re4t::cfg->bBalancedChicagoTypewriter);
+	iniReader.WriteBoolean("GAMEPLAY", "BalancedChicagoTypewriter", re4t::cfg->bBalancedChicagoTypewriter);
 	iniReader.WriteBoolean("GAMEPLAY", "UseSprintToggle", re4t::cfg->bUseSprintToggle);
 	iniReader.WriteBoolean("GAMEPLAY", "RifleScreenShake", re4t::cfg->bRifleScreenShake);
 	iniReader.WriteBoolean("GAMEPLAY", "DisableQTE", re4t::cfg->bDisableQTE);
@@ -1014,7 +1014,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "AllowAshleySuplex", re4t::cfg->bAllowAshleySuplex ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixDitmanGlitch", re4t::cfg->bFixDitmanGlitch ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "AllowSellingHandgunSilencer", re4t::cfg->bAllowSellingHandgunSilencer ? "true" : "false");
-	spd::log()->info("| {:<30} | {:>15} |", "BlancedChicagoTypewriter", re4t::cfg->bBalancedChicagoTypewriter ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "BalancedChicagoTypewriter", re4t::cfg->bBalancedChicagoTypewriter ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "UseSprintToggle", re4t::cfg->bUseSprintToggle ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "RifleScreenShake", re4t::cfg->bRifleScreenShake ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "DisableQTE", re4t::cfg->bDisableQTE ? "true" : "false");

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -321,6 +321,7 @@ void re4t_cfg::ReadSettings(std::wstring ini_path)
 	re4t::cfg->bForceETSApplyScale = iniReader.ReadBoolean("MISC", "ForceETSApplyScale", re4t::cfg->bForceETSApplyScale);
 	re4t::cfg->bAlwaysShowOriginalTitleBackground = iniReader.ReadBoolean("MISC", "AlwaysShowOriginalTitleBackground", re4t::cfg->bAlwaysShowOriginalTitleBackground);
 	re4t::cfg->bHideZoomControlHints = iniReader.ReadBoolean("MISC", "HideZoomControlHints", re4t::cfg->bHideZoomControlHints);
+	re4t::cfg->bFixSilencedHandgunDescription = iniReader.ReadBoolean("MISC", "FixSilencedHandgunDescription", re4t::cfg->bFixSilencedHandgunDescription);
 
 	// MEMORY
 	re4t::cfg->bAllowHighResolutionSFD = iniReader.ReadBoolean("MEMORY", "AllowHighResolutionSFD", re4t::cfg->bAllowHighResolutionSFD);
@@ -849,6 +850,7 @@ void WriteSettings(std::wstring iniPath, bool trainerIni)
 	iniReader.WriteBoolean("MISC", "EnableDebugMenu", re4t::cfg->bEnableDebugMenu);
 	iniReader.WriteBoolean("MISC", "ShowGameOutput", re4t::cfg->bShowGameOutput);
 	iniReader.WriteBoolean("MISC", "HideZoomControlHints", re4t::cfg->bHideZoomControlHints);
+	iniReader.WriteBoolean("MISC", "FixSilencedHandgunDescription", re4t::cfg->bFixSilencedHandgunDescription);
 	// Not writing EnableModExpansion / ForceETSApplyScale back to users INI in case those were enabled by a mod override INI (which the user might want to remove later)
 	// We don't have any UI options for those anyway, so pointless for us to write it back
 
@@ -1040,6 +1042,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "ForceETSApplyScale", re4t::cfg->bForceETSApplyScale ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "AlwaysShowOriginalTitleBg", re4t::cfg->bAlwaysShowOriginalTitleBackground ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "HideZoomControlHints", re4t::cfg->bHideZoomControlHints ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "FixSilencedHandgunDescription", re4t::cfg->bFixSilencedHandgunDescription ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");
 
 	// MEMORY

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -131,12 +131,13 @@ public:
 	bool bSkipIntroLogos = false;
 	bool bSkipMenuFades = false;
 	bool bSpeedUpQuitGame = true;
+	bool bAlwaysShowOriginalTitleBackground = false;
+	bool bHideZoomControlHints = false;
+	bool bFixSilencedHandgunDescription = true;
 	bool bEnableDebugMenu = false;
 	bool bShowGameOutput = false;
 	bool bEnableModExpansion = false;
 	bool bForceETSApplyScale = false;
-	bool bAlwaysShowOriginalTitleBackground = false;
-	bool bHideZoomControlHints = false;
   
 	// MEMORY
 	bool bAllowHighResolutionSFD = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1416,12 +1416,12 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Allows selling the (normally unused) handgun silencer to the merchant.");
 					}
 
-					// BlancedChicagoTypewriter
-					if ((OptionsFilter.PassFilter("BlancedChicagoTypewriter") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
+					// BalancedChicagoTypewriter
+					if ((OptionsFilter.PassFilter("BalancedChicagoTypewriter") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
 					{
 						ImGui_ColumnSwitch();
 
-						if (ImGui::Checkbox("BlancedChicagoTypewriter", &re4t::cfg->bBalancedChicagoTypewriter))
+						if (ImGui::Checkbox("BalancedChicagoTypewriter", &re4t::cfg->bBalancedChicagoTypewriter))
 						{
 							re4t::cfg->HasUnsavedChanges = true;
 							NeedsToRestart = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1656,6 +1656,45 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Speeds up the unnecessarily slow screen fade that takes place after you press \"Quit\" in the game's main menu.");
 					}
 
+					// AlwaysShowOriginalTitleBackground
+					if ((OptionsFilter.PassFilter("AlwaysShowOriginalTitleBackground") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
+					{
+						ImGui_ColumnSwitch();
+
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("AlwaysShowOriginalTitleBackground", &re4t::cfg->bAlwaysShowOriginalTitleBackground);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("After beating the game, force the game to always show the original main menu background image of Leon and Ashley.");
+					}
+
+					// HideZoomControlHints 
+					if ((OptionsFilter.PassFilter("HideZoomControlHints Rifle Scope Binoculars") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
+					{
+						ImGui_ColumnSwitch();
+
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("HideZoomControlHints", &re4t::cfg->bHideZoomControlHints);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Hide zoom control reminders from the weapon scope and binocular HUDs.");
+					}
+
+					// FixSilencedHandgunDescription
+					if ((OptionsFilter.PassFilter("FixSilencedHandgunDescription Silencer") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
+					{
+						ImGui_ColumnSwitch();
+
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("FixSilencedHandgunDescription", &re4t::cfg->bFixSilencedHandgunDescription);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Updates the silenced handgun's item description to only mention increased critical hit chance when the handgun is fully upgraded.");
+					}
+
 					// EnableDebugMenu
 					if ((OptionsFilter.PassFilter("EnableDebugMenu") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
 					{
@@ -1687,32 +1726,6 @@ void cfgMenuRender()
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 						ImGui::TextWrapped("Displays the game's original logs/debug output into a console window. (F2 by default)");					
-					}
-
-					// AlwaysShowOriginalTitleBackground
-					if ((OptionsFilter.PassFilter("AlwaysShowOriginalTitleBackground") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
-					{
-						ImGui_ColumnSwitch();
-
-						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("AlwaysShowOriginalTitleBackground", &re4t::cfg->bAlwaysShowOriginalTitleBackground);
-
-						ImGui_ItemSeparator();
-
-						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
-						ImGui::TextWrapped("After beating the game, force the game to always show the original main menu background image of Leon and Ashley.");
-					}
-
-					// HideZoomControlHints 
-					if ((OptionsFilter.PassFilter("HideZoomControlHints Rifle Scope Binoculars") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
-					{
-						ImGui_ColumnSwitch();
-
-						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("HideZoomControlHints", &re4t::cfg->bHideZoomControlHints);
-
-						ImGui_ItemSeparator();
-
-						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
-						ImGui::TextWrapped("Hide zoom control reminders from the weapon scope and binocular HUDs.");
 					}
 
 					ImGui_ColumnFinish();

--- a/dllmain/dllmain.vcxproj
+++ b/dllmain/dllmain.vcxproj
@@ -1045,6 +1045,7 @@ echo | set /p dummyName=#define GIT_BRANCH ^"%VAR%^" &gt;&gt; gitparams.h</Comma
     <ClInclude Include="SDK\item.h" />
     <ClInclude Include="SDK\light.h" />
     <ClInclude Include="sdk\merchant.h" />
+    <ClInclude Include="SDK\message.h" />
     <ClInclude Include="SDK\model.h" />
     <ClInclude Include="SDK\obj.h" />
     <ClInclude Include="SDK\objWep.h" />

--- a/dllmain/dllmain.vcxproj.filters
+++ b/dllmain/dllmain.vcxproj.filters
@@ -1629,6 +1629,9 @@
     <ClInclude Include="sdk\merchant.h">
       <Filter>dllmain\SDK</Filter>
     </ClInclude>
+    <ClInclude Include="SDK\message.h">
+      <Filter>dllmain\SDK</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="includes">

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -348,6 +348,12 @@ SpeedUpQuitGame = true
 ; After beating the game, force the game to always show the original main menu background image of Leon and Ashley.
 AlwaysShowOriginalTitleBackground = false
 
+; Hide zoom control reminders from the weapon scope and binocular HUDs.
+HideZoomControlHints = false
+
+; Updates the silenced handgun's item description to only mention increased critical hit chance when the handgun is fully upgraded.
+FixSilencedHandgunDescription = true
+
 ; Enables the "tool menu" debug menu, present inside the game but unused, and adds a few custom menu entries ("SAVE GAME", "DOF/BLUR MENU", etc).
 ; Can be opened with the LT+LS button combination (or CTRL+F3 by default on keyboard).
 ; If enabled on the 1.0.6 debug build it'll apply some fixes to the existing debug menu, fixing AREA JUMP etc, but won't add our custom entries due to lack of space.
@@ -368,9 +374,6 @@ EnableModExpansion = false
 ; If using this, make sure to remove the default invalid ETS scale values that the vanilla game has set!
 ; (modders that require this to be enabled can force it by including a override INI with their mod, see Modding-Enhancements link above)
 ForceETSApplyScale = false
-
-; Hide zoom control reminders from the weapon scope and binocular HUDs.
-HideZoomControlHints = false
 
 [MEMORY]
 ; Allocate more memory for SFD movie files, and properly scale its resolution display above 512x336.


### PR DESCRIPTION
https://github.com/nipkownix/re4_tweaks/issues/434

Workaround fix for [the silencer wrongly suggesting it gives the handgun a 5x crit chance](https://user-images.githubusercontent.com/116680301/211691071-2256ad09-a251-4f76-bc44-200203837815.jpg) when the handgun has less than max firepower:

![20230110161652_1](https://user-images.githubusercontent.com/116680301/211690906-ba743e87-ab68-430d-bb8c-2233f57aa801.jpg)

While we're here, remove the infinite bullets description from the unupgraded Chicago Typewriter:
![20230110191812_1](https://user-images.githubusercontent.com/116680301/211690891-6cdb7c0c-9ada-4025-8310-fd0f45c51264.jpg)
