### PR TITLE
Added config option for RifleScreenShake recoil strength

### DIFF
--- a/dllmain/Misc.cpp
+++ b/dllmain/Misc.cpp
@@ -1018,7 +1018,7 @@ void re4t::init::Misc()
 			void operator()(injector::reg_pack& regs)
 			{
 				if (re4t::cfg->bRifleScreenShake)
-					bio4::QuakeExec(0, 0, 5, 40.0f, 2u);
+					bio4::QuakeExec(0, 0, 5, 20 * re4t::cfg->fRifleScreenShakeRecoil, 2u);
 
 				// Code we overwrote
 				regs.edx = *(uint32_t*)(regs.esi + 0x7D8);

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -299,6 +299,7 @@ void re4t_cfg::ReadSettings(std::wstring ini_path)
 	re4t::cfg->bAllowSellingHandgunSilencer = iniReader.ReadBoolean("GAMEPLAY", "AllowSellingHandgunSilencer", re4t::cfg->bAllowSellingHandgunSilencer);
 	re4t::cfg->bUseSprintToggle = iniReader.ReadBoolean("GAMEPLAY", "UseSprintToggle", re4t::cfg->bUseSprintToggle);
 	re4t::cfg->bRifleScreenShake = iniReader.ReadBoolean("GAMEPLAY", "RifleScreenShake", re4t::cfg->bRifleScreenShake);
+	re4t::cfg->fRifleScreenShakeRecoil = iniReader.ReadFloat("GAMEPLAY", "RifleScreenShakeRecoil", re4t::cfg->fRifleScreenShakeRecoil);
 	re4t::cfg->bDisableQTE = iniReader.ReadBoolean("GAMEPLAY", "DisableQTE", re4t::cfg->bDisableQTE);
 	re4t::cfg->bAutomaticMashingQTE = iniReader.ReadBoolean("GAMEPLAY", "AutomaticMashingQTE", re4t::cfg->bAutomaticMashingQTE);
 	re4t::cfg->bAllowMatildaQuickturn = iniReader.ReadBoolean("GAMEPLAY", "AllowMatildaQuickturn", re4t::cfg->bAllowMatildaQuickturn);
@@ -828,6 +829,7 @@ void WriteSettings(std::wstring iniPath, bool trainerIni)
 	iniReader.WriteBoolean("GAMEPLAY", "AllowSellingHandgunSilencer", re4t::cfg->bAllowSellingHandgunSilencer);
 	iniReader.WriteBoolean("GAMEPLAY", "UseSprintToggle", re4t::cfg->bUseSprintToggle);
 	iniReader.WriteBoolean("GAMEPLAY", "RifleScreenShake", re4t::cfg->bRifleScreenShake);
+	iniReader.WriteFloat("GAMEPLAY", "RifleScreenShakeRecoil", re4t::cfg->fRifleScreenShakeRecoil);
 	iniReader.WriteBoolean("GAMEPLAY", "DisableQTE", re4t::cfg->bDisableQTE);
 	iniReader.WriteBoolean("GAMEPLAY", "AutomaticMashingQTE", re4t::cfg->bAutomaticMashingQTE);
 	iniReader.WriteBoolean("GAMEPLAY", "AllowMatildaQuickturn", re4t::cfg->bAllowMatildaQuickturn);
@@ -1012,6 +1014,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "AllowSellingHandgunSilencer", re4t::cfg->bAllowSellingHandgunSilencer ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "UseSprintToggle", re4t::cfg->bUseSprintToggle ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "RifleScreenShake", re4t::cfg->bRifleScreenShake ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "RifleScreenShakeRecoil", re4t::cfg->fRifleScreenShakeRecoil);
 	spd::log()->info("| {:<30} | {:>15} |", "DisableQTE", re4t::cfg->bDisableQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "AutomaticMashingQTE", re4t::cfg->bAutomaticMashingQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "AllowMatildaQuickturn", re4t::cfg->bAllowMatildaQuickturn ? "true" : "false");

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -115,6 +115,7 @@ public:
 	bool bAllowSellingHandgunSilencer = true;
 	bool bUseSprintToggle = false;
 	bool bRifleScreenShake = false;
+	float fRifleScreenShakeRecoil = 5.0f;
 	bool bDisableQTE = false;
 	bool bAutomaticMashingQTE = false;
 	bool bAllowMatildaQuickturn = false;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1452,6 +1452,17 @@ void cfgMenuRender()
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
 
 						ImGui::TextWrapped("Adds a screen shake effect when firing a rifle.");
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+
+						ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize("Recoil").x);
+						ImGui::BeginDisabled(!re4t::cfg->bRifleScreenShake);
+						ImGui::SliderFloat("Recoil", &re4t::cfg->fRifleScreenShakeRecoil, 0.0f, 10.0f, "%.1f");
+						ImGui::EndDisabled();
+						ImGui::PopItemWidth();
+
+						if (ImGui::IsItemEdited())
+							re4t::cfg->HasUnsavedChanges = true;
 					}
 
 					// QTE options

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -285,6 +285,7 @@ UseSprintToggle = false
 
 ; Adds a screen shake effect when firing a rifle.
 RifleScreenShake = false
+RifleScreenShakeRecoil = 5.0
 
 ; Disables most of the QTEs, making them pass automatically.
 DisableQTE = false


### PR DESCRIPTION
I was playing with this more and felt the effect was a little too muted, so I added in a slider to configure the recoil strength.

Edit: seems the reason I felt it was muted is because `QuakeExec` is weaker at 60fps, as mentioned here https://github.com/nipkownix/re4_tweaks/issues/333#issuecomment-1334413970 I was originally testing it at 30fps. Going to try and see if I can't figure out a 60fps fix for that first.