### PR TITLE
FrameRateFixes: Add FixCameraShakeEffects

### DIFF
--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -285,6 +285,7 @@ void re4t_cfg::ReadSettings(std::wstring ini_path)
 	re4t::cfg->bFixTurningSpeed = iniReader.ReadBoolean("FRAME RATE", "FixTurningSpeed", re4t::cfg->bFixTurningSpeed);
 	re4t::cfg->bFixQTE = iniReader.ReadBoolean("FRAME RATE", "FixQTE", re4t::cfg->bFixQTE);
 	re4t::cfg->bFixAshleyBustPhysics = iniReader.ReadBoolean("FRAME RATE", "FixAshleyBustPhysics", re4t::cfg->bFixAshleyBustPhysics);
+	re4t::cfg->bFixCameraShakeEffects = iniReader.ReadBoolean("FRAME RATE", "FixCameraShakeEffects", re4t::cfg->bFixCameraShakeEffects);
 	re4t::cfg->bEnableFastMath = iniReader.ReadBoolean("FRAME RATE", "EnableFastMath", re4t::cfg->bEnableFastMath);
 	re4t::cfg->bReplaceFramelimiter = iniReader.ReadBoolean("FRAME RATE", "ReplaceFramelimiter", re4t::cfg->bReplaceFramelimiter);
 	re4t::cfg->bMultithreadFix = iniReader.ReadBoolean("FRAME RATE", "MultithreadFix", re4t::cfg->bMultithreadFix);
@@ -816,6 +817,7 @@ void WriteSettings(std::wstring iniPath, bool trainerIni)
 	iniReader.WriteBoolean("FRAME RATE", "FixTurningSpeed", re4t::cfg->bFixTurningSpeed);
 	iniReader.WriteBoolean("FRAME RATE", "FixQTE", re4t::cfg->bFixQTE);
 	iniReader.WriteBoolean("FRAME RATE", "FixAshleyBustPhysics", re4t::cfg->bFixAshleyBustPhysics);
+	iniReader.WriteBoolean("FRAME RATE", "FixCameraShakeEffects", re4t::cfg->bFixCameraShakeEffects);
 	iniReader.WriteBoolean("FRAME RATE", "EnableFastMath", re4t::cfg->bEnableFastMath);
 	iniReader.WriteBoolean("FRAME RATE", "ReplaceFramelimiter", re4t::cfg->bReplaceFramelimiter);
 	iniReader.WriteBoolean("FRAME RATE", "MultithreadFix", re4t::cfg->bMultithreadFix);
@@ -1000,6 +1002,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "FixTurningSpeed", re4t::cfg->bFixTurningSpeed ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixQTE", re4t::cfg->bFixQTE ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "FixAshleyBustPhysics", re4t::cfg->bFixAshleyBustPhysics ? "true" : "false");
+	spd::log()->info("| {:<30} | {:>15} |", "FixCameraShakeEffects", re4t::cfg->bFixCameraShakeEffects ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "EnableFastMath", re4t::cfg->bEnableFastMath ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ReplaceFramelimiter", re4t::cfg->bReplaceFramelimiter ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "MultithreadFix", re4t::cfg->bMultithreadFix ? "true" : "false");

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -101,6 +101,7 @@ public:
 	bool bFixTurningSpeed = true;
 	bool bFixQTE = true;
 	bool bFixAshleyBustPhysics = true;
+	bool bFixCameraShakeEffects = true;
 	bool bEnableFastMath = true;
 	bool bReplaceFramelimiter = true;
 	bool bMultithreadFix = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1259,6 +1259,19 @@ void cfgMenuRender()
 						ImGui::TextWrapped("Fixes difference between 30/60FPS on physics applied to Ashley.");
 					}
 
+					// FixCameraShakeEffects
+					if ((OptionsFilter.PassFilter("FixCameraShakeEffects Quake") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
+					{
+						ImGui_ColumnSwitch();
+
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("FixCameraShakeEffects", &re4t::cfg->bFixCameraShakeEffects);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Fixes weak camera shake effects at framerates higher than 30fps.");
+					}
+
 					// EnableFastMath
 					if ((OptionsFilter.PassFilter("EnableFastMath") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
 					{

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -237,6 +237,9 @@ FixQTE = true
 ; Fixes difference between 30/60FPS on physics applied to Ashley.
 FixAshleyBustPhysics = true
 
+; Fixes weak camera shake effects at framerates higher than 30fps.
+FixCameraShakeEffects = true
+
 ; Replaces older math functions in the game with much more optimized equivalents.
 ; Experimental, can hopefully improve framerate in some areas that had dips.
 EnableFastMath = true


### PR DESCRIPTION
As mentioned here https://github.com/nipkownix/re4_tweaks/pull/439, I thought the rifle screenshake option seemed too muted until I realized from reading this https://github.com/nipkownix/re4_tweaks/issues/333#issuecomment-1334413970 comment that it was because playing at 60fps mutes the strength and duration of camera shake effects.

I tested this fix in 120fps at the r31c door and it looked good!

Edit: Hmm, after testing it more this doesn't seem like a proper fix. The camera is shakier at 60fps than it is at 30fps now. Too bad. I'll try to come up with a correct fix.