### PR TITLE
Misc minor fixes from static analyser

### DIFF
--- a/dllmain/AutoUpdater.cpp
+++ b/dllmain/AutoUpdater.cpp
@@ -264,7 +264,7 @@ void updateDownloadApply()
 			BOOL result_moveFile1 = MoveFileExW(new_module_path1.c_str(), new_module_path2.c_str(), MOVEFILE_REPLACE_EXISTING);
 			BOOL result_moveFile2 = MoveFileExW(new_ini_path1.c_str(), new_ini_path2.c_str(), MOVEFILE_REPLACE_EXISTING);
 			
-			if (!result_moveFile1 || !result_moveFile1)
+			if (!result_moveFile1 || !result_moveFile2)
 			{
 				spd::log()->info("{} -> Failed to rename file. Not critical, continuing...", __FUNCTION__);
 

--- a/dllmain/CommandLine.cpp
+++ b/dllmain/CommandLine.cpp
@@ -198,7 +198,7 @@ void re4t::init::CommandLine()
 			{
 				paramRoomValue = std::stoul(roomNumStr, nullptr, 16);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				paramRoomValue = 0;
 			}
@@ -210,7 +210,7 @@ void re4t::init::CommandLine()
 			{
 				paramLoadSaveSlot = std::stol(loadNum, nullptr, 0);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				paramLoadSaveSlot = 0;
 			}
@@ -229,7 +229,7 @@ void re4t::init::CommandLine()
 				int difficultyLevel = std::stol(difficulty, nullptr, 0);
 				difficultyValue = GameDifficulty(difficultyLevel);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				// not a number? check for some common difficulties
 				if (!_wcsicmp(difficulty, L"veryeasy"))
@@ -256,7 +256,7 @@ void re4t::init::CommandLine()
 			{
 				(*paramPosition).x = std::stof(posX);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				(*paramPosition).x = 0;
 			}
@@ -270,7 +270,7 @@ void re4t::init::CommandLine()
 			{
 				(*paramPosition).y = std::stof(posY);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				(*paramPosition).y = 0;
 			}
@@ -284,7 +284,7 @@ void re4t::init::CommandLine()
 			{
 				(*paramPosition).z = std::stof(posZ);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				(*paramPosition).z = 0;
 			}
@@ -296,7 +296,7 @@ void re4t::init::CommandLine()
 			{
 				paramRotation = std::stof(posR);
 			}
-			catch (std::exception e)
+			catch (const std::exception&)
 			{
 				paramRotation.reset();
 			}

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -179,7 +179,6 @@ std::unordered_map<int, std::string> EmNames =
 	{0x0F, "Boat"},
 	{0x11, "Zealot"},
 	{0x12, "Ganado"},
-	{0x13, "Ganado"},
 	{0x13, "Ganado / Merchant"},
 	{0x14, "Zealot / Merchant"},
 	{0x15, "Ganado"},

--- a/dllmain/Patches.h
+++ b/dllmain/Patches.h
@@ -65,7 +65,7 @@ struct EndSceneHook
 
 	float _cur_monitor_dpi = 1.0f;
 
-	ImFont* ESP_font;
+	ImFont* ESP_font = nullptr;
 
 	ImGuiContext* _imgui_context = nullptr;
 };

--- a/dllmain/QTEFixes.cpp
+++ b/dllmain/QTEFixes.cpp
@@ -97,7 +97,7 @@ void re4t::init::QTEfixes()
 	// Automatic QTEs
 	{
 		// QTEactive pointer
-		auto pattern = hook::pattern("c6 05 ? ? ? ? ? e8 ? ? ? ? 83 c4 ? 84 c0 0f 84");
+		auto pattern = hook::pattern("C6 05 ? ? ? ? ? E8 ? ? ? ? 83 C4 ? 84 C0 0F 84");
 		ptrQTEactive = *pattern.count(1).get(0).get<uint32_t*>(2);
 
 		// Hook cActionButton_checkButton
@@ -111,7 +111,7 @@ void re4t::init::QTEfixes()
 		{
 			void operator()(injector::reg_pack& regs)
 			{
-				if (re4t::cfg->bDisableQTE && (!re4t::cfg->bAutomaticMashingQTE || re4t::cfg->bAutomaticMashingQTE))
+				if (re4t::cfg->bDisableQTE)
 				{
 					if (isAutoQTE || isQTEactive())
 						regs.ef &= ~(1 << regs.zero_flag);
@@ -151,7 +151,7 @@ void re4t::init::QTEfixes()
 			pattern = hook::pattern("E8 ? ? ? ? 83 C4 10 85 C0 74 06 FF 86 ? ? ? ? 57");
 			InjectHook(pattern.count(1).get(0).get<uint32_t>(0), KeyTrgCheck_hook);
 
-			// Second
+			// Third
 			pattern = hook::pattern("E8 ? ? ? ? 83 C4 ? 85 C0 74 ? 8B 15 ? ? ? ? 8A 82");
 			InjectHook(pattern.count(1).get(0).get<uint32_t>(0), KeyTrgCheck_hook);
 		}
@@ -386,7 +386,7 @@ void re4t::init::QTEfixes()
 					// Get pointer to the timer float where the new time is going to be written
 					float* timer = (float*)(regs.esi + regs.eax * 0x8 + 0xA0);
 
-					// Write 0 if needed, otherwise write what the game calcualted
+					// Write 0 if needed, otherwise write what the game calculated
 					if (re4t::cfg->bDisableQTE || re4t::cfg->bAutomaticMashingQTE)
 						*timer = 0.0f;
 					else

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -546,7 +546,7 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 		std::wstring iniPath = rootPath + wrapperName + L".ini";
 
 		#ifdef VERBOSE
-		con.log("Writing main settings to: %s", WstrToStr(iniPath));
+		con.log("Writing main settings to: %s", WstrToStr(iniPath).c_str());
 		#endif
 
 		// Copy the default .ini to folder if one doesn't exist, just so we can keep comments and descriptions intact.
@@ -737,6 +737,8 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 
 		// Save main .ini file
 		ini.writeIni();
+
+		re4t::cfg->HasUnsavedChanges = false;
 	}
 
 	// trainer.ini-only settings
@@ -744,7 +746,7 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 		std::wstring iniPath = rootPath + L"re4_tweaks\\trainer.ini";
 
 		#ifdef VERBOSE
-		con.log("Writing trainer settings to: %s", WstrToStr(iniPath));
+		con.log("Writing trainer settings to: %s", WstrToStr(iniPath).c_str());
 		#endif
 
 		// Copy the default .ini to folder if one doesn't exist, just so we can keep comments and descriptions intact.
@@ -914,11 +916,7 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 
 		// Save trainer .ini file
 		ini.writeIni();
-
-		return;
 	}
-
-	re4t::cfg->HasUnsavedChanges = false;
 }
 
 void re4t_cfg::LogSettings()

--- a/dllmain/UI_Utility.cpp
+++ b/dllmain/UI_Utility.cpp
@@ -224,7 +224,7 @@ void ImGui_SetHotkeyThread(std::string* cfgHotkey)
 }
 
 bool ImGui_ButtonSameLine(const char* label, bool samelinecheck, float offset,
-	const ImVec2 size)
+	const ImVec2& size)
 {
 	bool ret = ImGui::Button(label, size);
 
@@ -246,8 +246,8 @@ bool ImGui_ButtonSameLine(const char* label, bool samelinecheck, float offset,
 }
 
 bool ImGui_TabButton(const char* btnID, const char* text, const ImVec4& activeCol,
-	const ImVec4& inactiveCol, MenuTab tabID, const char* icon, const ImColor iconColor,
-	const ImColor textColor, const ImVec2& size)
+	const ImVec4& inactiveCol, MenuTab tabID, const char* icon, const ImColor& iconColor,
+	const ImColor& textColor, const ImVec2& size)
 {
 	ImDrawList* drawList = ImGui::GetWindowDrawList();
 
@@ -277,8 +277,8 @@ bool ImGui_TabButton(const char* btnID, const char* text, const ImVec4& activeCo
 }
 
 bool ImGui_TrainerTabButton(const char* btnID, const char* text, const ImVec4& activeCol,
-	const ImVec4& inactiveCol, TrainerTab tabID, const char* icon, const ImColor iconColor,
-	const ImColor textColor, const ImVec2& size, const bool samelinecheck)
+	const ImVec4& inactiveCol, TrainerTab tabID, const char* icon, const ImColor& iconColor,
+	const ImColor& textColor, const ImVec2& size, const bool samelinecheck)
 {
 	ImDrawList* drawList = ImGui::GetWindowDrawList();
 

--- a/dllmain/UI_Utility.h
+++ b/dllmain/UI_Utility.h
@@ -54,14 +54,14 @@ void ImGui_SetHotkeyComboThread(std::string* cfgHotkey);
 void ImGui_SetHotkeyThread(std::string* cfgHotkey);
 
 bool ImGui_ButtonSameLine(const char* label, bool samelinecheck = true, 
-	float offset = 0.0f, const ImVec2 size = ImVec2(0, 0));
+	float offset = 0.0f, const ImVec2& size = ImVec2(0, 0));
 
 bool ImGui_TabButton(const char* btnID, const char* text, const ImVec4& activeCol,
-	const ImVec4& inactiveCol, MenuTab tabID, const char* icon, const ImColor iconColor,
-	const ImColor textColor, const ImVec2& size = ImVec2(0, 0));
+	const ImVec4& inactiveCol, MenuTab tabID, const char* icon, const ImColor& iconColor,
+	const ImColor& textColor, const ImVec2& size = ImVec2(0, 0));
 bool ImGui_TrainerTabButton(const char* btnID, const char* text, const ImVec4& activeCol,
-	const ImVec4& inactiveCol, TrainerTab tabID, const char* icon, const ImColor iconColor,
-	const ImColor textColor, const ImVec2& size = ImVec2(0, 0), const bool samelinecheck = true);
+	const ImVec4& inactiveCol, TrainerTab tabID, const char* icon, const ImColor& iconColor,
+	const ImColor& textColor, const ImVec2& size = ImVec2(0, 0), const bool samelinecheck = true);
 
 bool ImGui_BufferingBar(const char* label, float value, const ImVec2& size_arg, const ImU32& bg_col, const ImU32& fg_col);
 bool ImGui_Spinner(const char* label, float radius, int thickness, const ImU32& color);

--- a/dllmain/input.cpp
+++ b/dllmain/input.cpp
@@ -955,7 +955,7 @@ void re4t::input::init()
 			keystring = GetStrFromVK(i);
 	
 			_keyboardStringMap.insert(_keyboardStringMap.end(), std::pair<unsigned int, std::string>(i, keystring));
-			keystring = "";
+			keystring.clear();
 		}
 	
 		_keyboardStringMap[0x1B] = "ESCAPE";
@@ -1011,7 +1011,7 @@ void re4t::input::init()
 		_keyboardStringMap[0x66] = "NUMPAD_6";
 		_keyboardStringMap[0x67] = "NUMPAD_7";
 		_keyboardStringMap[0x68] = "NUMPAD_8";
-		_keyboardStringMap[0x68] = "NUMPAD_9";
+		_keyboardStringMap[0x69] = "NUMPAD_9";
 	
 		// Arrow keys
 		_keyboardStringMap[0x26] = "UP";

--- a/includes/iniReader.h
+++ b/includes/iniReader.h
@@ -16,11 +16,8 @@ class iniReader
 {
 public:
     // Use .ini path/filename from parameter
-    iniReader(const std::wstring& filename)
+    iniReader(const std::wstring& filename) : inipath(filename)
     {
-        // Store the ini path
-        inipath = filename;
-
         // Read and parse the INI file
         m_ini.LoadFile(filename.c_str());
     }


### PR DESCRIPTION
Fixes some minor issues flagged by static analyser, hopefully all the fixes here should be good, but let me know if anything seems wrong.

There were two other things it flagged that I'm not sure about atm, again just minor things though:

Two Em names are defined for 0x13 in Game.cpp:
https://github.com/nipkownix/re4_tweaks/blob/2ff10dd01a5ee460d979826f0b8cb6f68db078a6/dllmain/Game.cpp#L179-L183
There's also no name for Em10 defined there, maybe 0x11 was meant to be 0x10, 0x12 was meant to be 0x11, and first 0x13 was meant to be 0x12? I don't really know what the names of each enemy is though so no idea if that's the case 😅 

and there's a weird check in QTEFixes.cpp of `!var || var`, so it passes every time, is something meant to be checked there?
https://github.com/nipkownix/re4_tweaks/blob/2ff10dd01a5ee460d979826f0b8cb6f68db078a6/dllmain/QTEFixes.cpp#L114