### PR TITLE
ConsoleWnd: write game log msgs into log file, always log error msgs

### DIFF
--- a/dllmain/ConsoleWnd.cpp
+++ b/dllmain/ConsoleWnd.cpp
@@ -224,14 +224,12 @@ void __cdecl OSReport_hook(const char* msg, ...)
         buffer[strlen(buffer) - 1] = '\0';
     }
 
+    spd::log()->info("OSReport: {}", buffer);
     con.gameLog("OSReport: %s", buffer);
 }
 
 void OSPanic_nullsub_hook(const char* file, int line, const char* message, ...)
 {
-    if (!re4t::cfg->bShowGameOutput)
-        return;
-
     va_list args;
     char buffer[1024];
 
@@ -246,14 +244,12 @@ void OSPanic_nullsub_hook(const char* file, int line, const char* message, ...)
         buffer[strlen(buffer) - 1] = '\0';
     }
 
+    spd::log()->error("OSPanic: File: {}, Line: {}, Message: {}", file, line, buffer);
     con.gameLog("OSPanic: File: %s, Line: %d, Message: %s", file, line, buffer);
 }
 
 void cLog__err_nullsubver_hook(uint32_t flag, uint32_t errId, char* mes, ...)
 {
-    if (!re4t::cfg->bShowGameOutput)
-        return;
-
     va_list args;
     char buffer[1024];
 
@@ -268,14 +264,12 @@ void cLog__err_nullsubver_hook(uint32_t flag, uint32_t errId, char* mes, ...)
         buffer[strlen(buffer) - 1] = '\0';
     }
 
+    spd::log()->error("cLog::err: Flag: {}, errId: {}, Message: {}", flag, errId, buffer);
     con.gameLog("cLog::err: Flag: %d, errId: %d, Message: %s", flag, errId, buffer);
 }
 
 void cLog__err_1_hook(int a1, int a2, const char* message, ...)
 {
-    if (!re4t::cfg->bShowGameOutput)
-        return;
-
     va_list args;
     char buffer[1024];
 
@@ -290,6 +284,7 @@ void cLog__err_1_hook(int a1, int a2, const char* message, ...)
         buffer[strlen(buffer) - 1] = '\0';
     }
 
+    spd::log()->error("cLog::err_1: {}", buffer);
     con.gameLog("cLog::err_1: %s", buffer);
 }
 


### PR DESCRIPTION
Figured it'd be useful to always log any of the bad OSPanic etc messages (except for OSReport) into log file, might come in handy for crash reports (eg. @linkthehylian's crashing issues at #431 which are maybe mem related, can maybe help track down what fails)

Seems we didn't actually write these logs into our log file though, just console window, added some code to add to log too ~~but haven't been able to test it yet (not really sure how to make game cause an error to try it...)~~

(E: tried out patching part of game to always call OSPanic (nop 94855D) and seemed to log it fine, game did eventually crash after it spammed OSPanic a ton of times though, something in `ImFont::CalcTextSizeA+0x117 in DINPUT8.dll`)

Looks like it should be fine to me though, but let me know if you spot some issue with it.