### PR TITLE
ControllerTweaks: added SmoothAnalogTurning

### DIFF
--- a/dllmain/FrameRateFixes.cpp
+++ b/dllmain/FrameRateFixes.cpp
@@ -1481,7 +1481,8 @@ void re4t::init::FrameRateFixes()
 		}; injector::MakeInline<cR305Shutter__close_hook_2>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
 	}
 
-	// Fix character backwards turning speed
+	// Fix character backwards turning speed (continued from ControllerTweaks.cpp)
+	// is pl_R1_Crouch even used anywhere in the game? I suspect it is leftover code
 	{
 		struct TurnSpeedSubtract
 		{
@@ -1499,14 +1500,12 @@ void re4t::init::FrameRateFixes()
 
 		auto pattern = hook::pattern("D8 25 ? ? ? ? D9 ? A4 00 00 00");
 
-		// 0x7636d9 - pl_R1_Back
 		// 0x766069 - pl_R1_Crouch
 		// 0x7660b6 - pl_R1_Crouch
 		// 0x766167 - pl_R1_Crouch
 		// 0x7661b4 - pl_R1_Crouch
-		// 0x9001a3 - pl_R1_KlauserAttack
-		for (int i = 0; i < 6; i++)
-			injector::MakeInline<TurnSpeedSubtract>(pattern.count(6).get(i).get<uint32_t>(0), pattern.count(6).get(i).get<uint32_t>(6));
+		for (int i = 0; i < 4; i++)
+			injector::MakeInline<TurnSpeedSubtract>(pattern.count(4).get(i).get<uint32_t>(0), pattern.count(4).get(i).get<uint32_t>(6));
 
 		struct TurnSpeedAdd
 		{
@@ -1524,32 +1523,12 @@ void re4t::init::FrameRateFixes()
 
 		pattern = hook::pattern("D8 05 ? ? ? ? D9 ? A4 00 00 00");
 
-		// 0x7636fa - pl_R1_Back
 		// 0x76607b - pl_R1_Crouch
 		// 0x7660a4 - pl_R1_Crouch
 		// 0x766179 - pl_R1_Crouch
 		// 0x7661a2 - pl_R1_Crouch
-		for (int i = 0; i < 5; i++)
-			injector::MakeInline<TurnSpeedAdd>(pattern.count(5).get(i).get<uint32_t>(0), pattern.count(5).get(i).get<uint32_t>(6));
-
-		struct TurnSpeedLoad
-		{
-			void operator()(injector::reg_pack& regs)
-			{
-				float cPlayer__SPEED_WALK_TURN = 0.04188790545f; // game calcs this on startup, always seems to be same value
-				float newTurnSpeed = GlobalPtr()->deltaTime_70 * cPlayer__SPEED_WALK_TURN;
-
-				if (re4t::cfg->bFixTurningSpeed)
-					_asm {fld newTurnSpeed}
-				else
-					_asm {fld cPlayer__SPEED_WALK_TURN}
-			}
-		};
-
-		pattern = hook::pattern("D9 05 ? ? ? ? D8 86 A4 00 00 00 D9 9E A4 00 00 00");
-
-		// 0x9001C0 - pl_R1_KlauserAttack
-		injector::MakeInline<TurnSpeedLoad>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
+		for (int i = 0; i < 4; i++)
+			injector::MakeInline<TurnSpeedAdd>(pattern.count(4).get(i).get<uint32_t>(0), pattern.count(4).get(i).get<uint32_t>(6));
 	}
 
 	// Mercenaries: fix doubling of the village stage's passive difficulty gain in 60fps NTSC mode

--- a/dllmain/Settings.cpp
+++ b/dllmain/Settings.cpp
@@ -230,6 +230,7 @@ void ReadSettingsIni(std::wstring ini_path)
 		re4t::cfg->bOverrideXinputDeadzone = ini.getBool("CONTROLLER", "OverrideXinputDeadzone", re4t::cfg->bOverrideXinputDeadzone);
 		re4t::cfg->fXinputDeadzone = ini.getFloat("CONTROLLER", "XinputDeadzone", re4t::cfg->fXinputDeadzone);
 		re4t::cfg->fXinputDeadzone = fmin(fmax(re4t::cfg->fXinputDeadzone, 0.0f), 3.5f); // limit between 0.0 - 3.5
+		re4t::cfg->bSmoothAnalogTurning = ini.getBool("CONTROLLER", "SmoothAnalogTurning", re4t::cfg->bSmoothAnalogTurning);
 		re4t::cfg->bAllowReloadWithoutAiming_controller = ini.getBool("CONTROLLER", "AllowReloadWithoutAiming", re4t::cfg->bAllowReloadWithoutAiming_controller);
 		re4t::cfg->bReloadWithoutZoom_controller = ini.getBool("CONTROLLER", "ReloadWithoutZoom", re4t::cfg->bReloadWithoutZoom_controller);
 
@@ -677,6 +678,7 @@ void re4t_cfg::WriteSettings(bool trainerOnly)
 		ini.setBool("CONTROLLER", "RemoveExtraXinputDeadzone", re4t::cfg->bRemoveExtraXinputDeadzone);
 		ini.setBool("CONTROLLER", "OverrideXinputDeadzone", re4t::cfg->bOverrideXinputDeadzone);
 		ini.setFloat("CONTROLLER", "XinputDeadzone", re4t::cfg->fXinputDeadzone);
+		ini.setBool("CONTROLLER", "SmoothAnalogTurning", re4t::cfg->bSmoothAnalogTurning);
 		ini.setBool("CONTROLLER", "AllowReloadWithoutAiming", re4t::cfg->bAllowReloadWithoutAiming_controller);
 		ini.setBool("CONTROLLER", "ReloadWithoutZoom", re4t::cfg->bReloadWithoutZoom_controller);
 
@@ -1023,6 +1025,7 @@ void re4t_cfg::LogSettings()
 	spd::log()->info("| {:<30} | {:>15} |", "RemoveExtraXinputDeadzone", re4t::cfg->bRemoveExtraXinputDeadzone ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "OverrideXinputDeadzone", re4t::cfg->bOverrideXinputDeadzone ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "XinputDeadzone", re4t::cfg->fXinputDeadzone);
+	spd::log()->info("| {:<30} | {:>15} |", "SmoothAnalogTurning", re4t::cfg->bSmoothAnalogTurning ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "AllowReloadWithoutAiming", re4t::cfg->bAllowReloadWithoutAiming_controller ? "true" : "false");
 	spd::log()->info("| {:<30} | {:>15} |", "ReloadWithoutZoom", re4t::cfg->bReloadWithoutZoom_controller ? "true" : "false");
 	spd::log()->info("+--------------------------------+-----------------+");

--- a/dllmain/Settings.h
+++ b/dllmain/Settings.h
@@ -99,6 +99,7 @@ public:
 	float fXinputDeadzone = 0.4f;
 	bool bAllowReloadWithoutAiming_controller = false;
 	bool bReloadWithoutZoom_controller = false;
+	bool bSmoothAnalogTurning = false;
 
 	// FRAME RATE
 	bool bFixFallingItemsSpeed = true;

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1245,6 +1245,20 @@ void cfgMenuRender()
 							re4t::cfg->fXinputDeadzone = 1.0f;
 					}
 
+					// SmoothAnalogTurning
+					if ((OptionsFilter.PassFilter("SmoothAnalogTurning") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
+					{
+						ImGui_ColumnSwitch();
+
+						re4t::cfg->HasUnsavedChanges |= ImGui::Checkbox("SmoothAnalogTurning", &re4t::cfg->bSmoothAnalogTurning);
+
+						ImGui_ItemSeparator();
+
+						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
+						ImGui::TextWrapped("Enables smooth turning with the left analog stick, similar to the 'Classic' control schemes found in later Resident Evils.");
+						ImGui::TextWrapped("Best paired with minimal to no deadzone.");
+					}
+
 					// AllowReloadWithoutAiming_controller
 					if ((OptionsFilter.PassFilter("AllowReloadWithoutAiming") && OptionsFilter.IsActive()) || !OptionsFilter.IsActive())
 					{

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -219,6 +219,9 @@ RemoveExtraXinputDeadzone = true
 OverrideXinputDeadzone = true
 XinputDeadzone = 0.4
 
+; Enables smooth turning with the left analog stick, similar to the 'Classic' control schemes found in later Resident Evils.
+SmoothAnalogTurning = false
+
 ; Removes the need to be aiming the weapon before you can reload it.
 ; Warning: this will also change the reload button based on your current controller config type, 
 ; since the original button is used for sprinting when not aiming.


### PR DESCRIPTION
https://github.com/nipkownix/re4_tweaks/issues/145

This adds smooth analog turning for gamepad controls. It should feel very similar to the type A/B controls in RE5 and the 'Classic' controls in RE: Rev.


[smoothturn.webm](https://user-images.githubusercontent.com/116680301/222960655-54a665e4-6e65-43c1-9b6e-7fcbb941e893.webm)


Another major benefit to this option is that it's now possible to play with the deadzone slider set to 0 without struggling to keep Leon moving in a straight line.

[dinput8.zip](https://github.com/nipkownix/re4_tweaks/files/10891880/dinput8.zip)

Side note: I had to migrate some of the `bFixTurningSpeed` fixes here, which just left behind fixes for `pl_R1_Crouch`. Is that function actually used in the game anywhere, or is it a holdover from 3.5?