### PR TITLE
FixRetryLoadMouseSelector: crash fix

### DIFF
--- a/dllmain/KeyboardMouseTweaks.cpp
+++ b/dllmain/KeyboardMouseTweaks.cpp
@@ -359,7 +359,7 @@ void re4t::init::KeyboardMouseTweaks()
 			{
 				if (re4t::cfg->bFixRetryLoadMouseSelector)
 				{
-					if (*(int32_t*)ptrRetryLoadDLGstate != 1)
+					if (ptrRetryLoadDLGstate && *(int32_t*)ptrRetryLoadDLGstate != 1)
 					{
 						*(int32_t*)(regs.edi + 0x160) = regs.ecx;
 					}


### PR DESCRIPTION
This option kept crashing<sup>[[log](https://github.com/nipkownix/re4_tweaks/files/11007378/crash.log)]</sup> for me whenever I'd press escape to skip the Hunnigan cutscene at the start of R101. Added a null check and the crashes stopped.