### PR TITLE
Tweaked SmoothAnalogTurning

### DIFF
--- a/dllmain/ControllerTweaks.cpp
+++ b/dllmain/ControllerTweaks.cpp
@@ -153,7 +153,7 @@ void re4t::init::ControllerTweaks()
 					float deltaAnalogLX = RawAnalogLX / 32767.0f; // use RawAnalog so we can establish a deadzone independent of Xinput override
 					if (abs(deltaAnalogLX) > LXDeadZone)
 					{
-						float turnSpeed = cPlayer__SPEED_WALK_TURN * std::min((abs(deltaAnalogLX) - LXDeadZone) / (1.0f - LXDeadZone - .15f), 1.0f);
+						float turnSpeed = 1.4f * cPlayer__SPEED_WALK_TURN * std::min((abs(deltaAnalogLX) - LXDeadZone) / (1.0f - LXDeadZone - .10f), 1.0f);
 
 						if (deltaAnalogLX > 0.0f)
 							PlayerPtr()->ang_A0.y -= GlobalPtr()->deltaTime_70 * turnSpeed;
@@ -185,7 +185,7 @@ void re4t::init::ControllerTweaks()
 					float deltaAnalogLX = RawAnalogLX / 32767.0f;
 					if (abs(deltaAnalogLX) > LXDeadZone)
 					{
-						float turnSpeed = cPlayer__SPEED_RUN_TURN *  std::min((abs(deltaAnalogLX) - LXDeadZone) / (1.0f - LXDeadZone - .15f), 1.0f) * pl_speed2_xxx_1216;
+						float turnSpeed = 1.4f * cPlayer__SPEED_RUN_TURN *  std::min((abs(deltaAnalogLX) - LXDeadZone) / (1.0f - LXDeadZone - .10f), 1.0f) * pl_speed2_xxx_1216;
 
 						if (deltaAnalogLX > 0.0f)
 							PlayerPtr()->ang_A0.y -= GlobalPtr()->deltaTime_70 * turnSpeed;
@@ -214,7 +214,7 @@ void re4t::init::ControllerTweaks()
 				if (isController() && re4t::cfg->bSmoothAnalogTurning)
 				{
 					float deltaAnalogLX = RawAnalogLX / 32767.0f;
-					float turnSpeed = cPlayer__SPEED_WALK_TURN * std::min((deltaAnalogLX / (1.0f - .15f)), 1.0f);
+					float turnSpeed = 1.4f * cPlayer__SPEED_WALK_TURN * std::min((deltaAnalogLX / (1.0f - .10f)), 1.0f);
 
 					PlayerPtr()->ang_A0.y -= GlobalPtr()->deltaTime_70 * turnSpeed;
 				}

--- a/dllmain/cfgMenu.cpp
+++ b/dllmain/cfgMenu.cpp
@@ -1489,8 +1489,8 @@ void cfgMenuRender()
 						ImGui_ItemSeparator();
 
 						ImGui::Dummy(ImVec2(10, 10 * esHook._cur_monitor_dpi));
-						ImGui::TextWrapped("Unlocks minor difficulty boosts previously exclusive to the North American console versions of RE4.");
-						ImGui::TextWrapped("Higher starting adaptive difficulty, more difficult Ada missions, and a more difficult Mercenaries village stage.");
+						ImGui::TextWrapped("Unlocks minor difficulty modifiers previously exclusive to the North American console versions of RE4.");
+						ImGui::TextWrapped("Higher starting adaptive difficulty in Normal mode and Separate Ways, higher fixed difficulty in Assignment Ada, and unlocked dynamic difficulty in the Mercenaries village stage.");
 						ImGui::TextWrapped("Bottle caps require 3000 points in the shooting gallery, and Easy difficulty is removed from the title menu.");
 					}
 

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -278,8 +278,8 @@ AshleyJPCameraAngles = false
 ; Adds a menu to choose between Normal and Professional difficulty modes when starting a new game of Separate Ways.
 SeparateWaysProfessional = true
 
-; Unlocks minor difficulty boosts previously exclusive to the NTSC console versions of RE4.
-; Higher starting adaptive difficulty, more difficult Ada missions, and a more difficult Mercenaries village stage.
+; Unlocks minor difficulty modifiers previously exclusive to the North American console versions of RE4.
+; Higher starting adaptive difficulty in Normal mode and Separate Ways, higher fixed difficulty in Assignment Ada, and unlocked dynamic difficulty in the Mercenaries village stage.
 ; Bottle caps require 3000 points in the shooting gallery, and Easy difficulty is removed from the title menu.
 EnableNTSCMode = false
 


### PR DESCRIPTION
Small update for SmoothAnalogTurning after playtesting back and forth with RE5 some more, realized I needed to up the max turn speed so there's a smoother gradient to the standing left/right turn speed. Feels a lot better now.

Also, minor thing, but I wanted to make the starting difficulty modifiers from NTSC mode independent of restart just in case someone doesn't realize the option requires that when they first configure re4_tweaks and start a new game.