### PR TITLE
SmoothAnalogTurning: fixed acceleration curve

### DIFF
--- a/dllmain/ControllerTweaks.cpp
+++ b/dllmain/ControllerTweaks.cpp
@@ -143,7 +143,7 @@ void re4t::init::ControllerTweaks()
 		// pl_R1_Walk
 		auto pattern = hook::pattern("8B C1 83 E0 04 33 D2 0B C2 74 ? 8B ? ? ? ? ? D9");
 		static const float cPlayer__SPEED_WALK_TURN = 0.04188790545f; // game calcs this on startup, always seems to be same value
-		static const float AnalogMultiplier = 1.4f; // increase max turn speed when using analog input to smooth out the transition to stationary turning
+		static const float AnalogMultiplier = 1.6f; // increase max turn speed when using analog input to smooth out the transition to stationary turning
 		static const float LXDeadZone = 0.2f; // RE5 has a small horizontal deadzone when moving forwards but not backwards
 		struct WalkTurnHook
 		{

--- a/dllmain/ControllerTweaks.cpp
+++ b/dllmain/ControllerTweaks.cpp
@@ -143,7 +143,7 @@ void re4t::init::ControllerTweaks()
 		// pl_R1_Walk
 		auto pattern = hook::pattern("8B C1 83 E0 04 33 D2 0B C2 74 ? 8B ? ? ? ? ? D9");
 		static const float cPlayer__SPEED_WALK_TURN = 0.04188790545f; // game calcs this on startup, always seems to be same value
-		static const float AnalogMultiplier = 1.6f; // increase max turn speed when using analog input to smooth out the transition to stationary turning
+		static const float AnalogMultiplier = 1.5f; // increase max turn speed when using analog input to smooth out the transition to stationary turning
 		static const float LXDeadZone = 0.2f; // RE5 has a small horizontal deadzone when moving forwards but not backwards
 		struct WalkTurnHook
 		{


### PR DESCRIPTION
Did some more research and realized I needed to square the post-deadzone analog throw value to get a proper response curve when doing player rotation on an analog stick. *Now* it should feel right.

Test build:
[dinput8.zip](https://github.com/nipkownix/re4_tweaks/files/11107195/dinput8.zip)