### PR TITLE
Fix issues with the pitch and camera when Leon is paired with ashley

### DIFF
--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -1035,6 +1035,25 @@ void Trainer_Init()
 
 		pattern = hook::pattern("D9 83 ? ? ? ? 52 DC 0D ? ? ? ? 51 8D 45 ? D9 9D");
 		injector::MakeInline<calcOffset_depression>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(6));
+
+		// Makes the camera use the default offsets even if the player is paired with ashley, which fixes the pitch problems when they're paired
+		pattern = hook::pattern("A9 00 00 00 20 74 09 C6 86 B4 01 00 00 01");
+		struct UnpairAshley
+		{
+			void operator()(injector::reg_pack& regs)
+			{
+				if (re4t::cfg->bTrainerEnableFreeCam)
+					regs.ef |= (1 << regs.zero_flag);
+
+				else
+				{
+					if (regs.eax & 0x20000000)
+					{
+						regs.ef &= ~(1 << regs.zero_flag);
+					}
+				}
+			}
+		}; injector::MakeInline<UnpairAshley>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
 	}
 
 	// Hook DebugTrg stub to use our reimplemented version


### PR DESCRIPTION
When the player and ashley are paired, in CameraQuasiFPS::checkCameraType it makes m_trans_type_1B4 set to 1 rather than the default value of 0 (if the player is leon), which makes the camera use different offsets that can cause annoying/strange behavior in free cam.

With this hook it redirects the execution to the switch statement that checks for the current player, and since it's leon it would override whatever value and set it to 0.

The game keeps track of the pairing state, so whether free cam is checked or not it would go back to what it was just fine.

Here is a comparison:
https://youtu.be/GSjxwSIVgpU (without the changes)

https://youtu.be/RpIG5TdMH8E (with them)

 