### PR TITLE
Fix high-FPS sound-doubling by adding 30FPS/33ms timeslicing to SndCall

### DIFF
--- a/dllmain/AudioTweaks.cpp
+++ b/dllmain/AudioTweaks.cpp
@@ -109,19 +109,29 @@ bool __cdecl SndStop_Hook(uint32_t id, int time)
 		match = SndDedup::buffers[SndDedup::prev()].find(id);
 	}
 
-	if (match)
+	if (match && !match->isStopped)
 	{
-		if ((now - match->tick) < SndDedup::SLICE_DURATION)
+		if ((now - match->tick) < SndSlice::SLICE_DURATION) // Sound was started less than 33ms ago?
 		{
-			// Skip SndStop calls for sounds started less than 33ms ago.
 			// Some funcs use a `if (id) { SndStop(id); } id = SndCall(x)` pattern to start playing new sounds 
 			// At 30fps this is likely intended to allow interrupting an existing sound effect.
-			// Higher framerates can sometimes run this with the same SE multiple times within 33ms
+			// but higher framerates can sometimes run this with the same SE multiple times within 33ms
 			// Stopping and restarting the same sound before it can play, causing pops/cracks in the audio.
-			// 
-			// TODO: Possible this may cause some legit SndStop calls to become skipped, could be worth gating this check behind optional setting.
+			//
+			// It's possible some legitimate non-dupe SndStop calls might still happen in the 33ms window though
+			// So instead of stopping the sound here we'll set an expiry timer to stop it in next 33ms
+			// De-duped sounds will clear the timer inside SndCall, allowing it to continue playback, while Framelimiter_Hook will handle stopping any expired sounds.
+			{
+				match->expiryTick = match->tick + SndSlice::SLICE_DURATION;
+				match->sndStopParam = time;
+			}
+
 			return false;
 		}
+
+		// More than 33ms passed since sound started, allow game to stop it:
+		match->expiryTick = 0;
+		match->sndStopParam = 0;
 		match->isStopped = true;
 	}
 
@@ -150,17 +160,19 @@ uint32_t __cdecl SndCall_Hook(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t 
 
 	// Dedupe sound if it was within last 33ms and hasn't been stopped with SndStop.
 	// (TODO: would be better if we could just check the sndCallHandle status and not return any that are stopped?)
-	if (match && (now - match->tick) < SndDedup::SLICE_DURATION && !match->isStopped)
+	if (match && (now - match->tick) < SndSlice::SLICE_DURATION && !match->isStopped)
 	{
-		// TODO: Might be better to play the sound at 0 volume rather than returning handle of prev sound
+		// TODO: be better to play the sound at 0 volume rather than returning handle of prev sound
 		// (in case game code uses handle to check when sound has ended, since this currently returns handle of the earliest trigger of this sound)
 		// Haven't found a way to force SndCall to play muted though :/
+		match->expiryTick = 0;
+		match->sndStopParam = 0;
 		return match->sndCallHandle;
 	}
 
 	uint32_t result = bio4::SndCall(blk, call_no, pos, id, flag, pMod);
 
-	SndKey key{ ret, blk, call_no, pMod, flag, result, now, false };
+	SndKey key{ ret, blk, call_no, pMod, flag, result, now, false, 0, 0 };
 	if (!SndDedup::buffers[SndDedup::current].add(key))
 	{
 		static bool hasWarned = false;

--- a/dllmain/AudioTweaks.cpp
+++ b/dllmain/AudioTweaks.cpp
@@ -7,8 +7,7 @@
 #include "ConsoleWnd.h"
 
 using re4t::AudioTweaks::SndDedup;
-using re4t::AudioTweaks::SndKey;
-using re4t::AudioTweaks::SndSlice;
+using re4t::AudioTweaks::SndEntry;
 
 void(__cdecl* Snd_set_system_vol)(char flg, int16_t vol);
 void __cdecl Snd_set_system_vol_Hook(char flg, int16_t vol)
@@ -103,45 +102,31 @@ bool __cdecl SndStop_Hook(uint32_t id, int time)
 {
 	const double now = FramelimiterPrevTicks;
 
-	SndKey* match = SndDedup::buffers[SndDedup::current].find(id);
-	if (!match)
-	{
-		match = SndDedup::buffers[SndDedup::prev()].find(id);
-	}
+	SndEntry* match = SndDedup::find(id);
 
 	if (match && !match->isStopped)
 	{
-		if ((now - match->tick) < SndSlice::SLICE_DURATION) // Sound was started less than 33ms ago?
+		if ((now - match->startTick) < SndDedup::DEDUP_WINDOW)
 		{
-			// Some funcs use a `if (id) { SndStop(id); } id = SndCall(x)` pattern to start playing new sounds 
+			// Some funcs use an `if (id) { SndStop(id); } id = SndCall(x)` pattern to start playing new sounds 
 			// At 30fps this is likely intended to allow interrupting an existing sound effect.
 			// but higher framerates can sometimes run this with the same SE multiple times within 33ms
 			// Stopping and restarting the same sound before it can play, causing pops/cracks in the audio.
 			//
-			// It's possible some legitimate non-dupe SndStop calls might still happen in the 33ms window though
-			// So instead of stopping the sound here we'll set an expiry timer to stop it in next 33ms
-			// De-duped sounds will clear the timer inside SndCall, allowing it to continue playback, while Framelimiter_Hook will handle stopping any expired sounds.
-			if (SndDedup::QueueStop(id, time, now + SndSlice::SLICE_DURATION))
+			// Possible some legitimate non-dupe SndStop calls could also be happening though
+			// So instead of skipping the call entirely we'll set an expiry timer to stop it in next 33ms
+			// De-duped sounds will clear the timer inside SndCall, allowing it to continue playback, while 
+			// SndDedup::Tick will stop any expired sounds.
+			if (match->pendingStopAt == 0)
 			{
-				// Stop is queued, skip stopping it here.
-				return false;
+				match->pendingStopAt = now + SndDedup::DEDUP_WINDOW;
+				match->pendingStopParam = time;
 			}
-			else
-			{
-				static bool hasWarned = false;
-				if (!hasWarned)
-				{
-					hasWarned = true;
-#ifdef VERBOSE
-					con.log("SndStop_Hook: exceeded %d queued stops!", SndDedup::MAX_QUEUED_STOPS);
-#endif
-					spd::log()->info("SndStop_Hook: exceeded {} queued stops!", SndDedup::MAX_QUEUED_STOPS);
-				}
-			}
+			return false;
 		}
 
-		// More than 33ms passed since sound started, allow game to stop it:
-		SndDedup::CancelQueuedStop(match->sndCallHandle);
+		// Outside window: stop normally.
+		match->pendingStopAt = 0;
 		match->isStopped = true;
 	}
 
@@ -162,36 +147,33 @@ uint32_t __cdecl SndCall_Hook(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t 
 		con.log("SndCall blk %d call_no %d pos %p id %d flag %d pMod %p ret %p", blk, call_no, pos, id, flag, pMod, ret);
 #endif
 
-	SndKey* match = SndDedup::buffers[SndDedup::current].find(ret, blk, call_no, flag, pMod);
-	if (!match)
-	{
-		match = SndDedup::buffers[SndDedup::prev()].find(ret, blk, call_no, flag, pMod);
-	}
+	SndEntry* match = SndDedup::find(ret, blk, call_no, flag, pMod);
 
 	// Dedupe sound if it was within last 33ms and hasn't been stopped with SndStop.
 	// (TODO: would be better if we could just check the sndCallHandle status and not return any that are stopped?)
-	if (match && (now - match->tick) < SndSlice::SLICE_DURATION && !match->isStopped)
+	if (match && (now - match->startTick) < SndDedup::DEDUP_WINDOW && !match->isStopped)
 	{
+		// Duplicate inside the window, reuse the prior handle and cancel any pending stop on it.
 		// TODO: be better to play the sound at 0 volume rather than returning handle of prev sound
 		// (in case game code uses handle to check when sound has ended, since this currently returns handle of the earliest trigger of this sound)
 		// Haven't found a way to force SndCall to play muted though :/
-		SndDedup::CancelQueuedStop(match->sndCallHandle);
+		match->pendingStopAt = 0;
 		return match->sndCallHandle;
 	}
 
 	uint32_t result = bio4::SndCall(blk, call_no, pos, id, flag, pMod);
 
-	SndKey key{ ret, blk, call_no, pMod, flag, result, now, false };
-	if (!SndDedup::buffers[SndDedup::current].add(key))
+	SndEntry entry{ ret, blk, call_no, pMod, flag, result, now, 0.0, 0, false };
+	if (!SndDedup::add(entry))
 	{
 		static bool hasWarned = false;
 		if (!hasWarned)
 		{
 			hasWarned = true;
 #ifdef VERBOSE
-			con.log("SndCall_Hook: exceeded %d entries in a single timeslice!", SndSlice::MAX_ENTRIES);
+			con.log("SndCall_Hook: exceeded %zu entries!", SndDedup::MAX_ENTRIES);
 #endif
-			spd::log()->info("SndCall_Hook: exceeded {} entries in a single timeslice!", SndSlice::MAX_ENTRIES);
+			spd::log()->info("SndCall_Hook: exceeded {} entries!", SndDedup::MAX_ENTRIES);
 		}
 	}
 

--- a/dllmain/AudioTweaks.cpp
+++ b/dllmain/AudioTweaks.cpp
@@ -101,6 +101,8 @@ extern double FramelimiterPrevTicks;
 
 bool __cdecl SndStop_Hook(uint32_t id, int time)
 {
+	const double now = FramelimiterPrevTicks;
+
 	SndKey* match = SndDedup::buffers[SndDedup::current].find(id);
 	if (!match)
 	{
@@ -109,6 +111,17 @@ bool __cdecl SndStop_Hook(uint32_t id, int time)
 
 	if (match)
 	{
+		if ((now - match->tick) < SndDedup::SLICE_DURATION)
+		{
+			// Skip SndStop calls for sounds started less than 33ms ago.
+			// Some funcs use a `if (id) { SndStop(id); } id = SndCall(x)` pattern to start playing new sounds 
+			// At 30fps this is likely intended to allow interrupting an existing sound effect.
+			// Higher framerates can sometimes run this with the same SE multiple times within 33ms
+			// Stopping and restarting the same sound before it can play, causing pops/cracks in the audio.
+			// 
+			// TODO: Possible this may cause some legit SndStop calls to become skipped, could be worth gating this check behind optional setting.
+			return false;
+		}
 		match->isStopped = true;
 	}
 

--- a/dllmain/AudioTweaks.cpp
+++ b/dllmain/AudioTweaks.cpp
@@ -6,6 +6,10 @@
 #include "AudioTweaks.h"
 #include "ConsoleWnd.h"
 
+using re4t::AudioTweaks::SndDedup;
+using re4t::AudioTweaks::SndKey;
+using re4t::AudioTweaks::SndSlice;
+
 void(__cdecl* Snd_set_system_vol)(char flg, int16_t vol);
 void __cdecl Snd_set_system_vol_Hook(char flg, int16_t vol)
 {
@@ -93,70 +97,71 @@ uint32_t __cdecl knife_r3_fire10_SndCall_Hook(uint16_t blk, uint16_t call_no, Ve
 	return bio4::SndCall(blk, call_no, pos, id, flag, pMod);
 }
 
-struct SndKey {
-	void* ret_addr;
-	uint16_t  blk;
-	uint16_t  call_no;
-	cModel* pMod;
-	uint32_t sndCallRet;
-};
+extern double FramelimiterPrevTicks;
+
+bool __cdecl SndStop_Hook(uint32_t id, int time)
+{
+	SndKey* match = SndDedup::buffers[SndDedup::current].find(id);
+	if (!match)
+	{
+		match = SndDedup::buffers[SndDedup::prev()].find(id);
+	}
+
+	if (match)
+	{
+		match->isStopped = true;
+	}
+
+	return bio4::SndStop(id, time);
+}
 
 // SndCall_Hook: tracks all SndCall usages inside a 33ms/30FPS timeslice.
 // If we see a duplicate call (same blk/call_no/pMod/ret_addr) inside the current timeslice, skip it and return previous SndCall result
 // Fixes issues with sounds becoming doubled in volume/reverb at higher framerates.
 uint32_t __cdecl SndCall_Hook(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t id, uint32_t flag, cModel* pMod)
 {
-	extern double FramelimiterPrevTicks;
+	void* ret = _ReturnAddress();
+	const double now = FramelimiterPrevTicks;
 
-	static constexpr size_t MAX_ENTRIES = 256;
-	static SndKey entries[MAX_ENTRIES];
-	static size_t count = 0;
-	static double last_tick = 0;
+	// Spammy, enable for testing:
+#ifdef SNDCALL_HOOK_TEST
+	if (blk != 5)
+		con.log("SndCall blk %d call_no %d pos %p id %d flag %d pMod %p ret %p", blk, call_no, pos, id, flag, pMod, ret);
+#endif
 
-	double elapsed = FramelimiterPrevTicks - last_tick;
-
-	// Check if reached end of 33ms timeslice
-	if (elapsed >= (1000.f / 30.0f))
+	SndKey* match = SndDedup::buffers[SndDedup::current].find(ret, blk, call_no, flag, pMod);
+	if (!match)
 	{
-		count = 0;
-		last_tick = FramelimiterPrevTicks;
+		match = SndDedup::buffers[SndDedup::prev()].find(ret, blk, call_no, flag, pMod);
 	}
 
-	SndKey key{ _ReturnAddress(), blk, call_no, pMod };
-
-	for (size_t i = 0; i < count; i++)
+	// Dedupe sound if it was within last 33ms and hasn't been stopped with SndStop.
+	// (TODO: would be better if we could just check the sndCallHandle status and not return any that are stopped?)
+	if (match && (now - match->tick) < SndDedup::SLICE_DURATION && !match->isStopped)
 	{
-		if (entries[i].pMod == key.pMod &&
-			entries[i].call_no == key.call_no &&
-			entries[i].blk == key.blk &&
-			entries[i].ret_addr == key.ret_addr)
-		{			
-			// TODO: Might be better to play the sound at 0 volume rather than returning handle of prev sound
-			// (in case game code uses handle to check when sound has ended, since this currently returns handle of the earliest trigger of this sound)
-			// Haven't found a way to force SndCall to play muted though :/
-			return entries[i].sndCallRet;
-		}
+		// TODO: Might be better to play the sound at 0 volume rather than returning handle of prev sound
+		// (in case game code uses handle to check when sound has ended, since this currently returns handle of the earliest trigger of this sound)
+		// Haven't found a way to force SndCall to play muted though :/
+		return match->sndCallHandle;
 	}
 
-	if (count >= MAX_ENTRIES)
+	uint32_t result = bio4::SndCall(blk, call_no, pos, id, flag, pMod);
+
+	SndKey key{ ret, blk, call_no, pMod, flag, result, now, false };
+	if (!SndDedup::buffers[SndDedup::current].add(key))
 	{
-		// 256 SndCalls within 33ms is unlikely, but log it just in case
 		static bool hasWarned = false;
 		if (!hasWarned)
 		{
 			hasWarned = true;
 #ifdef VERBOSE
-			con.log("SndCall_Hook: exceeded %d entries in a single timeslice!", MAX_ENTRIES);
+			con.log("SndCall_Hook: exceeded %d entries in a single timeslice!", SndSlice::MAX_ENTRIES);
 #endif
-			spd::log()->info("SndCall_Hook: exceeded {} entries in a single timeslice!", MAX_ENTRIES);
+			spd::log()->info("SndCall_Hook: exceeded {} entries in a single timeslice!", SndSlice::MAX_ENTRIES);
 		}
-
-		return bio4::SndCall(blk, call_no, pos, id, flag, pMod);
 	}
 
-	key.sndCallRet = bio4::SndCall(blk, call_no, pos, id, flag, pMod);
-	entries[count++] = key;
-	return key.sndCallRet;
+	return result;
 }
 
 void re4t::init::AudioTweaks()
@@ -165,6 +170,10 @@ void re4t::init::AudioTweaks()
 	auto pattern = hook::pattern("05 94 00 00 00 50 6A 0C 6A 01 E8");
 	if (re4t::cfg->bReplaceFramelimiter) // Requires tick count from new framelimiter
 		InjectHook(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0xA)).as_int(), SndCall_Hook);
+
+	pattern = hook::pattern("E8 06 00 00 6A 00 50 E8 ? ? ? ?");
+	if (re4t::cfg->bReplaceFramelimiter) // Requires tick count from new framelimiter
+		InjectHook(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0x7)).as_int(), SndStop_Hook);
 
 	// Hook Snd_set_system_vol so we can override volume values with our own after game updates them
 	pattern = hook::pattern("B8 10 00 00 00 0F B6 55 ? 52 50 E8 ? ? ? ? 83 C4");

--- a/dllmain/AudioTweaks.cpp
+++ b/dllmain/AudioTweaks.cpp
@@ -4,6 +4,7 @@
 #include "Game.h"
 #include "Settings.h"
 #include "AudioTweaks.h"
+#include "ConsoleWnd.h"
 
 void(__cdecl* Snd_set_system_vol)(char flg, int16_t vol);
 void __cdecl Snd_set_system_vol_Hook(char flg, int16_t vol)
@@ -92,10 +93,81 @@ uint32_t __cdecl knife_r3_fire10_SndCall_Hook(uint16_t blk, uint16_t call_no, Ve
 	return bio4::SndCall(blk, call_no, pos, id, flag, pMod);
 }
 
+struct SndKey {
+	void* ret_addr;
+	uint16_t  blk;
+	uint16_t  call_no;
+	cModel* pMod;
+	uint32_t sndCallRet;
+};
+
+// SndCall_Hook: tracks all SndCall usages inside a 33ms/30FPS timeslice.
+// If we see a duplicate call (same blk/call_no/pMod/ret_addr) inside the current timeslice, skip it and return previous SndCall result
+// Fixes issues with sounds becoming doubled in volume/reverb at higher framerates.
+uint32_t __cdecl SndCall_Hook(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t id, uint32_t flag, cModel* pMod)
+{
+	extern double FramelimiterPrevTicks;
+
+	static constexpr size_t MAX_ENTRIES = 256;
+	static SndKey entries[MAX_ENTRIES];
+	static size_t count = 0;
+	static double last_tick = 0;
+
+	double elapsed = FramelimiterPrevTicks - last_tick;
+
+	// Check if reached end of 33ms timeslice
+	if (elapsed >= (1000.f / 30.0f))
+	{
+		count = 0;
+		last_tick = FramelimiterPrevTicks;
+	}
+
+	SndKey key{ _ReturnAddress(), blk, call_no, pMod };
+
+	for (size_t i = 0; i < count; i++)
+	{
+		if (entries[i].pMod == key.pMod &&
+			entries[i].call_no == key.call_no &&
+			entries[i].blk == key.blk &&
+			entries[i].ret_addr == key.ret_addr)
+		{			
+			// TODO: Might be better to play the sound at 0 volume rather than returning handle of prev sound
+			// (in case game code uses handle to check when sound has ended, since this currently returns handle of the earliest trigger of this sound)
+			// Haven't found a way to force SndCall to play muted though :/
+			return entries[i].sndCallRet;
+		}
+	}
+
+	if (count >= MAX_ENTRIES)
+	{
+		// 256 SndCalls within 33ms is unlikely, but log it just in case
+		static bool hasWarned = false;
+		if (!hasWarned)
+		{
+			hasWarned = true;
+#ifdef VERBOSE
+			con.log("SndCall_Hook: exceeded %d entries in a single timeslice!", MAX_ENTRIES);
+#endif
+			spd::log()->info("SndCall_Hook: exceeded {} entries in a single timeslice!", MAX_ENTRIES);
+		}
+
+		return bio4::SndCall(blk, call_no, pos, id, flag, pMod);
+	}
+
+	key.sndCallRet = bio4::SndCall(blk, call_no, pos, id, flag, pMod);
+	entries[count++] = key;
+	return key.sndCallRet;
+}
+
 void re4t::init::AudioTweaks()
 {
+	// Hook SndCall to prevent duplicate calls within 33ms of each other
+	auto pattern = hook::pattern("05 94 00 00 00 50 6A 0C 6A 01 E8");
+	if (re4t::cfg->bReplaceFramelimiter) // Requires tick count from new framelimiter
+		InjectHook(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0xA)).as_int(), SndCall_Hook);
+
 	// Hook Snd_set_system_vol so we can override volume values with our own after game updates them
-	auto pattern = hook::pattern("B8 10 00 00 00 0F B6 55 ? 52 50 E8 ? ? ? ? 83 C4");
+	pattern = hook::pattern("B8 10 00 00 00 0F B6 55 ? 52 50 E8 ? ? ? ? 83 C4");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0xB)).as_int(), Snd_set_system_vol);
 	InjectHook(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0xB)).as_int(), Snd_set_system_vol_Hook);
 

--- a/dllmain/AudioTweaks.cpp
+++ b/dllmain/AudioTweaks.cpp
@@ -121,17 +121,27 @@ bool __cdecl SndStop_Hook(uint32_t id, int time)
 			// It's possible some legitimate non-dupe SndStop calls might still happen in the 33ms window though
 			// So instead of stopping the sound here we'll set an expiry timer to stop it in next 33ms
 			// De-duped sounds will clear the timer inside SndCall, allowing it to continue playback, while Framelimiter_Hook will handle stopping any expired sounds.
+			if (SndDedup::QueueStop(id, time, now + SndSlice::SLICE_DURATION))
 			{
-				match->expiryTick = match->tick + SndSlice::SLICE_DURATION;
-				match->sndStopParam = time;
+				// Stop is queued, skip stopping it here.
+				return false;
 			}
-
-			return false;
+			else
+			{
+				static bool hasWarned = false;
+				if (!hasWarned)
+				{
+					hasWarned = true;
+#ifdef VERBOSE
+					con.log("SndStop_Hook: exceeded %d queued stops!", SndDedup::MAX_QUEUED_STOPS);
+#endif
+					spd::log()->info("SndStop_Hook: exceeded {} queued stops!", SndDedup::MAX_QUEUED_STOPS);
+				}
+			}
 		}
 
 		// More than 33ms passed since sound started, allow game to stop it:
-		match->expiryTick = 0;
-		match->sndStopParam = 0;
+		SndDedup::CancelQueuedStop(match->sndCallHandle);
 		match->isStopped = true;
 	}
 
@@ -165,14 +175,13 @@ uint32_t __cdecl SndCall_Hook(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t 
 		// TODO: be better to play the sound at 0 volume rather than returning handle of prev sound
 		// (in case game code uses handle to check when sound has ended, since this currently returns handle of the earliest trigger of this sound)
 		// Haven't found a way to force SndCall to play muted though :/
-		match->expiryTick = 0;
-		match->sndStopParam = 0;
+		SndDedup::CancelQueuedStop(match->sndCallHandle);
 		return match->sndCallHandle;
 	}
 
 	uint32_t result = bio4::SndCall(blk, call_no, pos, id, flag, pMod);
 
-	SndKey key{ ret, blk, call_no, pMod, flag, result, now, false, 0, 0 };
+	SndKey key{ ret, blk, call_no, pMod, flag, result, now, false };
 	if (!SndDedup::buffers[SndDedup::current].add(key))
 	{
 		static bool hasWarned = false;

--- a/dllmain/AudioTweaks.h
+++ b/dllmain/AudioTweaks.h
@@ -5,5 +5,94 @@ namespace re4t
 	namespace AudioTweaks
 	{
 		void UpdateVolume();
+
+		struct SndKey
+		{
+			void* ret_addr;
+			uint16_t blk;
+			uint16_t call_no;
+			cModel* pMod;
+			uint32_t flag;
+			uint32_t sndCallHandle;
+			double tick;
+			bool isStopped;
+		};
+
+		struct SndSlice
+		{
+			static constexpr size_t MAX_ENTRIES = 256;
+			SndKey entries[MAX_ENTRIES];
+			size_t count = 0;
+
+			void clear() { count = 0; }
+
+			SndKey* find(void* ret, uint16_t blk, uint16_t call_no, uint32_t flag, cModel* pMod)
+			{
+				for (size_t i = 0; i < count; i++)
+				{
+					if (entries[i].pMod == pMod &&
+						entries[i].flag == flag &&
+						entries[i].call_no == call_no &&
+						entries[i].blk == blk &&
+						entries[i].ret_addr == ret)
+						return &entries[i];
+				}
+				return nullptr;
+			}
+
+			SndKey* find(uint32_t sndCallHandle)
+			{
+				for (size_t i = 0; i < count; i++)
+				{
+					if (entries[i].sndCallHandle == sndCallHandle)
+						return &entries[i];
+				}
+				return nullptr;
+			}
+
+			bool add(const SndKey& key)
+			{
+				if (count >= MAX_ENTRIES)
+					return false;
+				entries[count++] = key;
+				return true;
+			}
+		};
+
+		class SndDedup
+		{
+		public:
+			static constexpr double SLICE_DURATION = 1000.0 / 30.0;
+
+			// Two buffers rotated every ~33ms, duplicates are checked against both so sounds straddling a timeslice boundary are still caught.
+			// Matches in the previous buffer are only accepted if within the 33ms dedup window.
+			static inline SndSlice buffers[2];
+			static inline int current = 0;
+			static inline double slice_start = 0;
+
+			// Called once per frame from `Framelimiter_Hook`
+			static void Tick(double now)
+			{
+				double elapsed = now - slice_start;
+
+				if (elapsed >= SLICE_DURATION)
+				{
+					if (elapsed >= (SLICE_DURATION * 2))
+					{
+						buffers[0].clear();
+						buffers[1].clear();
+					}
+					else
+					{
+						current ^= 1;
+						buffers[current].clear();
+					}
+
+					slice_start = now;
+				}
+			}
+
+			static int prev() { return current ^ 1; }
+		};
 	}
 }

--- a/dllmain/AudioTweaks.h
+++ b/dllmain/AudioTweaks.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 
 namespace re4t
 {
@@ -16,10 +17,13 @@ namespace re4t
 			uint32_t sndCallHandle;
 			double tick;
 			bool isStopped;
+			double expiryTick;
+			int sndStopParam;
 		};
 
 		struct SndSlice
 		{
+			static constexpr double SLICE_DURATION = 1000.0 / 30.0;
 			static constexpr size_t MAX_ENTRIES = 256;
 			SndKey entries[MAX_ENTRIES];
 			size_t count = 0;
@@ -50,6 +54,17 @@ namespace re4t
 				return nullptr;
 			}
 
+			void on_expired(double now, std::function<void(SndKey*)> expiredCb)
+			{
+				for (size_t i = 0; i < count; i++)
+				{
+					if (entries[i].expiryTick == 0)
+						continue;
+					if (now - entries[i].expiryTick >= SLICE_DURATION)
+						expiredCb(&entries[i]);
+				}
+			}
+
 			bool add(const SndKey& key)
 			{
 				if (count >= MAX_ENTRIES)
@@ -62,7 +77,6 @@ namespace re4t
 		class SndDedup
 		{
 		public:
-			static constexpr double SLICE_DURATION = 1000.0 / 30.0;
 
 			// Two buffers rotated every ~33ms, duplicates are checked against both so sounds straddling a timeslice boundary are still caught.
 			// Matches in the previous buffer are only accepted if within the 33ms dedup window.
@@ -71,13 +85,16 @@ namespace re4t
 			static inline double slice_start = 0;
 
 			// Called once per frame from `Framelimiter_Hook`
-			static void Tick(double now)
+			static void Tick(double now, std::function<void(SndKey*)> expiredCb)
 			{
 				double elapsed = now - slice_start;
 
-				if (elapsed >= SLICE_DURATION)
+				buffers[0].on_expired(now, expiredCb);
+				buffers[1].on_expired(now, expiredCb);
+
+				if (elapsed >= SndSlice::SLICE_DURATION)
 				{
-					if (elapsed >= (SLICE_DURATION * 2))
+					if (elapsed >= (SndSlice::SLICE_DURATION * 2))
 					{
 						buffers[0].clear();
 						buffers[1].clear();

--- a/dllmain/AudioTweaks.h
+++ b/dllmain/AudioTweaks.h
@@ -17,8 +17,14 @@ namespace re4t
 			uint32_t sndCallHandle;
 			double tick;
 			bool isStopped;
-			double expiryTick;
+		};
+
+		struct SndQueuedStop
+		{
+			uint32_t sndCallHandle;
 			int sndStopParam;
+			double expiryTick;
+			bool active;
 		};
 
 		struct SndSlice
@@ -54,17 +60,6 @@ namespace re4t
 				return nullptr;
 			}
 
-			void on_expired(double now, std::function<void(SndKey*)> expiredCb)
-			{
-				for (size_t i = 0; i < count; i++)
-				{
-					if (entries[i].expiryTick == 0)
-						continue;
-					if (now - entries[i].expiryTick >= SLICE_DURATION)
-						expiredCb(&entries[i]);
-				}
-			}
-
 			bool add(const SndKey& key)
 			{
 				if (count >= MAX_ENTRIES)
@@ -77,21 +72,82 @@ namespace re4t
 		class SndDedup
 		{
 		public:
-
 			// Two buffers rotated every ~33ms, duplicates are checked against both so sounds straddling a timeslice boundary are still caught.
 			// Matches in the previous buffer are only accepted if within the 33ms dedup window.
 			static inline SndSlice buffers[2];
 			static inline int current = 0;
 			static inline double slice_start = 0;
 
-			// Called once per frame from `Framelimiter_Hook`
-			static void Tick(double now, std::function<void(SndKey*)> expiredCb)
+			// Deferred stops live separately from the dedup buffers so buffer rotation can't eat any pending stops.
+			static constexpr size_t MAX_QUEUED_STOPS = 256;
+			static inline SndQueuedStop queuedStops[MAX_QUEUED_STOPS];
+			static inline size_t queuedStopCount = 0;
+
+			static bool QueueStop(uint32_t sndCallHandle, int time, double expiryTick)
 			{
+				// Check if already queued
+				for (size_t i = 0; i < queuedStopCount; i++)
+				{
+					if (queuedStops[i].active && queuedStops[i].sndCallHandle == sndCallHandle)
+						return true;
+				}
+
+				// Try to reuse an inactive slot
+				for (size_t i = 0; i < queuedStopCount; i++)
+				{
+					if (!queuedStops[i].active)
+					{
+						queuedStops[i] = { sndCallHandle, time, expiryTick, true };
+						return true;
+					}
+				}
+
+				if (queuedStopCount < MAX_QUEUED_STOPS)
+				{
+					queuedStops[queuedStopCount++] = { sndCallHandle, time, expiryTick, true };
+					return true;
+				}
+
+				// No room in the queue?
+				return false;
+			}
+
+			static bool CancelQueuedStop(uint32_t sndCallHandle)
+			{
+				for (size_t i = 0; i < queuedStopCount; i++)
+				{
+					if (queuedStops[i].active && queuedStops[i].sndCallHandle == sndCallHandle)
+					{
+						queuedStops[i].active = false;
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			// Called once per frame from `Framelimiter_Hook`
+			static void Tick(double now, std::function<void(uint32_t id, int time)> stopCb)
+			{
+				// Process any queued stops
+				for (size_t i = 0; i < queuedStopCount; i++)
+				{
+					if (queuedStops[i].active && now >= queuedStops[i].expiryTick)
+					{
+						stopCb(queuedStops[i].sndCallHandle, queuedStops[i].sndStopParam);
+
+						// Mark the dedup entry so SndCall_Hook won't return this stale handle
+						SndKey* key = buffers[current].find(queuedStops[i].sndCallHandle);
+						if (!key)
+							key = buffers[prev()].find(queuedStops[i].sndCallHandle);
+						if (key)
+							key->isStopped = true;
+
+						queuedStops[i].active = false;
+					}
+				}
+
 				double elapsed = now - slice_start;
-
-				buffers[0].on_expired(now, expiredCb);
-				buffers[1].on_expired(now, expiredCb);
-
 				if (elapsed >= SndSlice::SLICE_DURATION)
 				{
 					if (elapsed >= (SndSlice::SLICE_DURATION * 2))

--- a/dllmain/AudioTweaks.h
+++ b/dllmain/AudioTweaks.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <functional>
 
 namespace re4t
 {
@@ -7,165 +6,95 @@ namespace re4t
 	{
 		void UpdateVolume();
 
-		struct SndKey
-		{
-			void* ret_addr;
-			uint16_t blk;
-			uint16_t call_no;
-			cModel* pMod;
-			uint32_t flag;
-			uint32_t sndCallHandle;
-			double tick;
-			bool isStopped;
-		};
+        struct SndEntry
+        {
+            // Dedup key
+            void* ret_addr;
+            uint16_t blk;
+            uint16_t call_no;
+            cModel* pMod;
+            uint32_t flag;
 
-		struct SndQueuedStop
-		{
-			uint32_t sndCallHandle;
-			int sndStopParam;
-			double expiryTick;
-			bool active;
-		};
+            // Tracking
+            uint32_t sndCallHandle;
+            double startTick;
 
-		struct SndSlice
-		{
-			static constexpr double SLICE_DURATION = 1000.0 / 30.0;
-			static constexpr size_t MAX_ENTRIES = 256;
-			SndKey entries[MAX_ENTRIES];
-			size_t count = 0;
+            // Deferred stop (pendingStopAt == 0 means none queued)
+            double pendingStopAt;
+            int pendingStopParam;
 
-			void clear() { count = 0; }
+            bool isStopped;
+        };
 
-			SndKey* find(void* ret, uint16_t blk, uint16_t call_no, uint32_t flag, cModel* pMod)
-			{
-				for (size_t i = 0; i < count; i++)
-				{
-					if (entries[i].pMod == pMod &&
-						entries[i].flag == flag &&
-						entries[i].call_no == call_no &&
-						entries[i].blk == blk &&
-						entries[i].ret_addr == ret)
-						return &entries[i];
-				}
-				return nullptr;
-			}
+        class SndDedup
+        {
+        public:
+            static constexpr double DEDUP_WINDOW = 1000.0 / 30.0; // ~33ms
+            static constexpr size_t MAX_ENTRIES = 512;
 
-			SndKey* find(uint32_t sndCallHandle)
-			{
-				for (size_t i = 0; i < count; i++)
-				{
-					if (entries[i].sndCallHandle == sndCallHandle)
-						return &entries[i];
-				}
-				return nullptr;
-			}
+            static inline SndEntry entries[MAX_ENTRIES];
+            static inline size_t   count = 0;
 
-			bool add(const SndKey& key)
-			{
-				if (count >= MAX_ENTRIES)
-					return false;
-				entries[count++] = key;
-				return true;
-			}
-		};
+            static SndEntry* find(void* ret, uint16_t blk, uint16_t call_no, uint32_t flag, cModel* pMod)
+            {
+                for (size_t i = count; i > 0; --i)
+                {
+                    SndEntry& e = entries[i - 1];
+                    if (e.pMod == pMod && e.flag == flag && e.call_no == call_no &&
+                        e.blk == blk && e.ret_addr == ret)
+                        return &e;
+                }
+                return nullptr;
+            }
 
-		class SndDedup
-		{
-		public:
-			// Two buffers rotated every ~33ms, duplicates are checked against both so sounds straddling a timeslice boundary are still caught.
-			// Matches in the previous buffer are only accepted if within the 33ms dedup window.
-			static inline SndSlice buffers[2];
-			static inline int current = 0;
-			static inline double slice_start = 0;
+            static SndEntry* find(uint32_t sndCallHandle)
+            {
+                for (size_t i = count; i > 0; --i)
+                {
+                    if (entries[i - 1].sndCallHandle == sndCallHandle)
+                        return &entries[i - 1];
+                }
+                return nullptr;
+            }
 
-			// Deferred stops live separately from the dedup buffers so buffer rotation can't eat any pending stops.
-			static constexpr size_t MAX_QUEUED_STOPS = 256;
-			static inline SndQueuedStop queuedStops[MAX_QUEUED_STOPS];
-			static inline size_t queuedStopCount = 0;
+            static SndEntry* add(const SndEntry& entry)
+            {
+                if (count >= MAX_ENTRIES)
+                    return nullptr;
+                entries[count] = entry;
+                return &entries[count++];
+            }
 
-			static bool QueueStop(uint32_t sndCallHandle, int time, double expiryTick)
-			{
-				// Check if already queued
-				for (size_t i = 0; i < queuedStopCount; i++)
-				{
-					if (queuedStops[i].active && queuedStops[i].sndCallHandle == sndCallHandle)
-						return true;
-				}
+            // Called once per frame from Framelimiter_Hook.
+            // Fires any expired pending stops, then compacts out entries that are past
+            // the dedup window and have no pending stop.
+            template<typename StopFn>
+            static void Tick(double now, StopFn&& stopCb)
+            {
+                size_t write = 0;
+                for (size_t read = 0; read < count; ++read)
+                {
+                    SndEntry& e = entries[read];
 
-				// Try to reuse an inactive slot
-				for (size_t i = 0; i < queuedStopCount; i++)
-				{
-					if (!queuedStops[i].active)
-					{
-						queuedStops[i] = { sndCallHandle, time, expiryTick, true };
-						return true;
-					}
-				}
+                    if (e.pendingStopAt > 0 && now >= e.pendingStopAt)
+                    {
+                        stopCb(e.sndCallHandle, e.pendingStopParam);
+                        e.pendingStopAt = 0;
+                        e.isStopped = true;
+                    }
 
-				if (queuedStopCount < MAX_QUEUED_STOPS)
-				{
-					queuedStops[queuedStopCount++] = { sndCallHandle, time, expiryTick, true };
-					return true;
-				}
+                    const bool inWindow = (now - e.startTick) < DEDUP_WINDOW;
+                    const bool hasPendingStop = (e.pendingStopAt > 0);
 
-				// No room in the queue?
-				return false;
-			}
-
-			static bool CancelQueuedStop(uint32_t sndCallHandle)
-			{
-				for (size_t i = 0; i < queuedStopCount; i++)
-				{
-					if (queuedStops[i].active && queuedStops[i].sndCallHandle == sndCallHandle)
-					{
-						queuedStops[i].active = false;
-						return true;
-					}
-				}
-
-				return false;
-			}
-
-			// Called once per frame from `Framelimiter_Hook`
-			static void Tick(double now, std::function<void(uint32_t id, int time)> stopCb)
-			{
-				// Process any queued stops
-				for (size_t i = 0; i < queuedStopCount; i++)
-				{
-					if (queuedStops[i].active && now >= queuedStops[i].expiryTick)
-					{
-						stopCb(queuedStops[i].sndCallHandle, queuedStops[i].sndStopParam);
-
-						// Mark the dedup entry so SndCall_Hook won't return this stale handle
-						SndKey* key = buffers[current].find(queuedStops[i].sndCallHandle);
-						if (!key)
-							key = buffers[prev()].find(queuedStops[i].sndCallHandle);
-						if (key)
-							key->isStopped = true;
-
-						queuedStops[i].active = false;
-					}
-				}
-
-				double elapsed = now - slice_start;
-				if (elapsed >= SndSlice::SLICE_DURATION)
-				{
-					if (elapsed >= (SndSlice::SLICE_DURATION * 2))
-					{
-						buffers[0].clear();
-						buffers[1].clear();
-					}
-					else
-					{
-						current ^= 1;
-						buffers[current].clear();
-					}
-
-					slice_start = now;
-				}
-			}
-
-			static int prev() { return current ^ 1; }
-		};
+                    if (inWindow || hasPendingStop)
+                    {
+                        if (write != read)
+                            entries[write] = e;
+                        ++write;
+                    }
+                }
+                count = write;
+            }
+        };
 	}
 }

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -155,9 +155,7 @@ void Framelimiter_Hook(uint8_t isAliveEvt_result)
 
 	// Update our SndCall dedupe tracker, and handle stopping any expired sounds.
 	// TODO: Move this call to a better spot.
-	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks, [](uint32_t id, int time) {
-		bio4::SndStop(id, time);
-	});
+	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks, bio4::SndStop);
 }
 
 std::recursive_mutex g_D3DMutex;

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -5,6 +5,7 @@
 #include "Game.h"
 #include "Settings.h"
 #include <timeapi.h>
+#include "AudioTweaks.h"
 
 uintptr_t ptrGXCopyTex;
 uintptr_t ptrAfterItemExamineHook;
@@ -151,6 +152,9 @@ void Framelimiter_Hook(uint8_t isAliveEvt_result)
 	GlobalPtr()->deltaTime_70 = float((timeElapsed / 1000) * 30.0);
 
 	SetThreadAffinityMask(curThread, prevAffinityMask);
+
+	// TODO: Move this call to a better spot.
+	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks);
 }
 
 std::recursive_mutex g_D3DMutex;

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -153,8 +153,14 @@ void Framelimiter_Hook(uint8_t isAliveEvt_result)
 
 	SetThreadAffinityMask(curThread, prevAffinityMask);
 
+	// Update our SndCall dedupe tracker, and handle stopping any expired sounds.
 	// TODO: Move this call to a better spot.
-	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks);
+	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks, [](re4t::AudioTweaks::SndKey* match) {
+		match->expiryTick = 0;
+		match->sndStopParam = 0;
+		match->isStopped = true;
+		bio4::SndStop(match->sndCallHandle, match->sndStopParam);
+	});
 }
 
 std::recursive_mutex g_D3DMutex;

--- a/dllmain/DisplayTweaks.cpp
+++ b/dllmain/DisplayTweaks.cpp
@@ -155,11 +155,8 @@ void Framelimiter_Hook(uint8_t isAliveEvt_result)
 
 	// Update our SndCall dedupe tracker, and handle stopping any expired sounds.
 	// TODO: Move this call to a better spot.
-	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks, [](re4t::AudioTweaks::SndKey* match) {
-		match->expiryTick = 0;
-		match->sndStopParam = 0;
-		match->isStopped = true;
-		bio4::SndStop(match->sndCallHandle, match->sndStopParam);
+	re4t::AudioTweaks::SndDedup::Tick(FramelimiterPrevTicks, [](uint32_t id, int time) {
+		bio4::SndStop(id, time);
 	});
 }
 

--- a/dllmain/Game.cpp
+++ b/dllmain/Game.cpp
@@ -77,6 +77,7 @@ namespace bio4 {
 	void(__cdecl* PlChangeData)();
 
 	uint32_t(__cdecl* SndCall)(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t id, uint32_t flag, cModel* pMod);
+	bool(__cdecl* SndStop)(uint32_t id, int time);
 	bool(__cdecl* SndStrReq_0)(uint32_t snd_id, int flg, int time, int vol);
 
 	bool(__cdecl* SubScreenOpen)(SS_OPEN_FLAG open_flag, SS_ATTR_FLAG attr_flag);
@@ -1135,6 +1136,10 @@ bool re4t::init::Game()
 	// SndCall funcptr
 	pattern = hook::pattern("05 94 00 00 00 50 6A 0C 6A 01 E8");
 	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0xA)).as_int(), bio4::SndCall);
+
+	// SndStop funcptr
+	pattern = hook::pattern("E8 06 00 00 6A 00 50 E8 ? ? ? ?");
+	ReadCall(injector::GetBranchDestination(pattern.count(1).get(0).get<uint32_t>(0x7)).as_int(), bio4::SndStop);
 
 	// SndStrReq_0 funcptr
 	pattern = hook::pattern("E8 ? ? ? ? 83 C4 10 5F B0 01 5E 8B");

--- a/dllmain/SDK/snd.h
+++ b/dllmain/SDK/snd.h
@@ -120,5 +120,6 @@ static_assert(sizeof(SND_SEQ) == 0x8C, "sizeof(SND_SEQ)");
 namespace bio4
 {
 	extern uint32_t(__cdecl* SndCall)(uint16_t blk, uint16_t call_no, Vec* pos, uint8_t id, uint32_t flag, cModel* pMod);
+	extern bool(__cdecl* SndStop)(uint32_t id, int time);
 	extern bool(__cdecl* SndStrReq_0)(uint32_t snd_id, int flg, int time, int vol);
 };


### PR DESCRIPTION
One of main issues when playing above 60FPS (and probably above 30FPS) are certain sound effects being doubled, causing them to either increase volume or just get doubled entirely.
Footstep sounds are most noticeable but also affects some sounds from NPCs (picking up hay etc)

This seems to help those, sounds mostly match across 30FPS/60FPS/120FPS for me now, and gets rid of the weird reverb effect they had.
(wondering if this might help some audio issues that were reported at vanilla 60FPS as well #300, but not totally sure)

For this we just keep a static array tracking each calls `blk`/`call_no`/`pMod ptr`/return-addr, and time it was last played, each call is checked if it's already been played in last 33ms, if so then call is skipped, and we just return the sound-handle ID from the previous call.

Makes 120FPS a lot more viable to play now that footsteps don't sound like ass :P
Probably still a lot of audio issues with it though, didn't notice any major problems playing through for an hour, but always a chance it might break something.

---

**Release build download:** https://github.com/nipkownix/re4_tweaks/actions/runs/24751303372/artifacts/6567262546
You can switch to 120FPS+ by setting `UseDynamicFrametime` and `DisableFramelimiting` to true in dinput8.ini (but this might also help 60FPS too)

Notes:
  
- If you get crash loading into map at high FPS try restarting game, might have a fix for this soon (seems to be caused by them using separate audio thread without proper thread-safety... might be able to move most of that into main thread though)

- Some sounds are still triggered more frequently at higher FPS, eg. the cow breathing sounds, and maybe the Ganados talking to each other
  Looks like cows use RNG to decide if sound should be played, and since that RNG-check code runs at faster framerate, more of those checks occur and pass in the same amount of time.
Probably not an easy way to fix this besides hooking those funcs and adding a similar 33ms check (I'd guess 60FPS also has this issue too but 120FPS makes it way more noticeable.)

- This returns handle to the earliest trigger of the sound in the timeslice.
Might be code that checks handle to see if sound has finished in order to trigger something else, since we return an earlier instance of the sound, could cause things to trigger slightly earlier than they should (1-4 frames early)
Not sure if game ever does try checking sound handles though, only saw a single check in some menu func so far.
Tried making this mute the dupe sounds instead of skipping them but no luck with that yet :(