### PR TITLE
Fix raw mouse delta being multiplied during slow frames

### DIFF
--- a/dllmain/KeyboardMouseTweaks.cpp
+++ b/dllmain/KeyboardMouseTweaks.cpp
@@ -186,7 +186,11 @@ void re4t::init::KeyboardMouseTweaks()
 			{
 				double deltaX = 0;
 				if (re4t::cfg->bUseRawMouseInput)
-					deltaX = (pInput->raw_mouse_delta_x() / 10.0f) * g_MOUSE_SENS();
+				{
+					// The game can run more than one update while recovering from a slow frame.
+					// Consume the movement so those updates cannot apply the same delta repeatedly.
+					deltaX = (pInput->consume_raw_mouse_delta_x() / 10.0f) * g_MOUSE_SENS();
+				}
 				else
 					deltaX = double(int(regs.eax));
 
@@ -207,7 +211,10 @@ void re4t::init::KeyboardMouseTweaks()
 			{
 				double deltaY = 0;
 				if (re4t::cfg->bUseRawMouseInput)
-					deltaY = -((pInput->raw_mouse_delta_y() / 7.0f) * g_MOUSE_SENS());
+				{
+					// See MouseDeltaX above. Each axis is consumed by its corresponding hook.
+					deltaY = -((pInput->consume_raw_mouse_delta_y() / 7.0f) * g_MOUSE_SENS());
+				}
 				else
 					deltaY = double(int(regs.eax));
 

--- a/dllmain/input.cpp
+++ b/dllmain/input.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Originally part of "ReShade", Copyright (C) 2014 Patrick Mours. All rights reserved.
  * License: https://github.com/crosire/reshade#license
  */
@@ -167,8 +167,12 @@ bool re4t::input::handle_window_message(const void* message_data)
 				input->_raw_mouse_absolutePos[1] = raw_data.data.mouse.lLastY;
 
 				// Update the delta values based on the difference between the current and previous absolute positions
-				input->_raw_mouse_delta[0] += input->_raw_mouse_absolutePos[0] - input->_raw_mouse_prevAbsolutePos[0];
-				input->_raw_mouse_delta[1] += input->_raw_mouse_absolutePos[1] - input->_raw_mouse_prevAbsolutePos[1];
+				const int delta_x = input->_raw_mouse_absolutePos[0] - input->_raw_mouse_prevAbsolutePos[0];
+				const int delta_y = input->_raw_mouse_absolutePos[1] - input->_raw_mouse_prevAbsolutePos[1];
+				input->_raw_mouse_delta[0] += delta_x;
+				input->_raw_mouse_delta[1] += delta_y;
+				input->_raw_mouse_game_delta[0] += delta_x;
+				input->_raw_mouse_game_delta[1] += delta_y;
 
 				// Update the previous absolute position
 				input->_raw_mouse_prevAbsolutePos[0] = input->_raw_mouse_absolutePos[0];
@@ -179,6 +183,8 @@ bool re4t::input::handle_window_message(const void* message_data)
 				// Update the delta values
 				input->_raw_mouse_delta[0] += raw_data.data.mouse.lLastX;
 				input->_raw_mouse_delta[1] += raw_data.data.mouse.lLastY;
+				input->_raw_mouse_game_delta[0] += raw_data.data.mouse.lLastX;
+				input->_raw_mouse_game_delta[1] += raw_data.data.mouse.lLastY;
 			}
 
 			if (raw_data.data.mouse.usButtonFlags & RI_MOUSE_LEFT_BUTTON_DOWN)
@@ -438,6 +444,22 @@ void re4t::input::max_mouse_position(unsigned int position[2]) const
 	GetClientRect(static_cast<HWND>(_window), &rect);
 	position[0] = rect.right;
 	position[1] = rect.bottom;
+}
+
+int re4t::input::consume_raw_mouse_delta_x()
+{
+	const std::unique_lock<std::shared_mutex> lock(_mutex);
+	const int delta = _raw_mouse_game_delta[0];
+	_raw_mouse_game_delta[0] = 0;
+	return delta;
+}
+
+int re4t::input::consume_raw_mouse_delta_y()
+{
+	const std::unique_lock<std::shared_mutex> lock(_mutex);
+	const int delta = _raw_mouse_game_delta[1];
+	_raw_mouse_game_delta[1] = 0;
+	return delta;
 }
 
 void re4t::input::next_frame()

--- a/dllmain/input.hpp
+++ b/dllmain/input.hpp
@@ -85,11 +85,15 @@ namespace re4t
 
 		auto raw_mouse_delta_x() { auto delta = static_cast<int>(_raw_mouse_delta[0]); /*_raw_mouse_delta[0] = 0;*/ return delta; }
 		auto raw_mouse_delta_y() { auto delta = static_cast<int>(_raw_mouse_delta[1]); /*_raw_mouse_delta[1] = 0;*/ return delta; }
+		int consume_raw_mouse_delta_x();
+		int consume_raw_mouse_delta_y();
 
 		void clear_raw_mouse_delta()
 		{
 			_raw_mouse_delta[0] = 0;
 			_raw_mouse_delta[1] = 0;
+			_raw_mouse_game_delta[0] = 0;
+			_raw_mouse_game_delta[1] = 0;
 		}
 
 		void clear_mouse_wheel_delta()
@@ -175,6 +179,7 @@ namespace re4t
 		std::wstring _text_input;
 
 		int _raw_mouse_delta[2] = {};
+		int _raw_mouse_game_delta[2] = {};
 		int _raw_mouse_absolutePos[2] = {};
 		int _raw_mouse_prevAbsolutePos[2] = {};
 	};


### PR DESCRIPTION
Fixes #460
Supersedes the workaround proposed in #645

**Problem**
Raw mouse input accumulated from `WM_INPUT` was stored in a single buffer whose lifetime was tied to `next_frame()`. Gameplay hooks could read the same accumulated delta more than once, while input arriving after gameplay had already read the buffer could instead be cleared by `next_frame()` before the next gameplay update consumed it.

Under load, this made raw mouse aiming inconsistent and noticeably choppy even when the game remained close to its target frame rate.

**Fix**
* Maintain a separate `_raw_mouse_game_delta` buffer dedicated to gameplay.
* Provide `consume_raw_mouse_delta_x()` and `consume_raw_mouse_delta_y()`, which read the current value under lock and immediately zero it.
* Update the X and Y gameplay hooks in `KeyboardMouseTweaks.cpp` to call the consume variants.
* Leave the existing `raw_mouse_delta_x/y` buffer untouched so menus, cutscenes, and any other non-gameplay consumers continue to behave as before.
* Lock consumption against concurrent raw-input writes using the existing `_mutex`.
* **Do not** clear `_raw_mouse_game_delta` in `next_frame()`, only explicit consumption or `clear_raw_mouse_delta()` should zero it, preventing unconsumed gameplay delta from being discarded at the frame boundary.

**Before:** (Aiming is choppy and unresponsive, especially in room r208)

https://github.com/user-attachments/assets/2ebfc61f-f03a-417c-8767-516e896fc6b5



**After:** (Aiming is smooth and responsive)

https://github.com/user-attachments/assets/505372bf-9bcf-4f72-a370-5cbb9059868c

